### PR TITLE
Failing to ignore case when scanning Call-ID value and support for compact header i:

### DIFF
--- a/src/sip.c
+++ b/src/sip.c
@@ -194,8 +194,12 @@ sip_get_callid(const char* payload)
     char value[256];
 
     for (pch = strtok(body, "\n"); pch; pch = strtok(NULL, "\n")) {
-        if (!strncasecmp(pch, "Call-ID", 7)) {
-            if (sscanf(pch, "Call-ID: %[^@\r\n]", value) == 1) {
+        if (!strncasecmp(pch, "Call-ID:", 8)) {
+            if (sscanf(&pch[8], " %[^@\r\n]", value) == 1) {
+                callid = strdup(value);
+            }
+        } else if (!strncasecmp(pch, "i:", 2)) {
+            if (sscanf(&pch[2], "%[^@\r\n]", value) == 1) {
                 callid = strdup(value);
             }
         }


### PR DESCRIPTION
Hello, 
sngrep will not catch messages if Call-ID header is not capitalized. For example, it will fail to catch message with this:
call-id: 3848276298220188511@atlanta.example.com

And it will not get messages with this one either:
i:3848276298220188511@atlanta.example.com

I have these issues corrected.
