### PR TITLE
bump to latest automake on freebsd

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,7 +19,7 @@ case `uname -sr` in
                 ;;
         FreeBSD*)
                 AUTOCONF_VERSION=2.69
-                AUTOMAKE_VERSION=1.12
+                AUTOMAKE_VERSION=1.15
                 export AUTOCONF_VERSION
                 export AUTOMAKE_VERSION
                 ;;


### PR DESCRIPTION
freebsd is now at version 1.15 for automake.
https://www.freshports.org/devel/automake/

1.12 looks like it was from June 2012