### PR TITLE
Keystroke propagation to previous panel/s

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1280,6 +1280,10 @@ call_flow_handle_key(PANEL *panel, int key)
                 call_raw_set_group(info->group);
                 call_raw_set_msg(call_flow_arrow_message(info->cur_arrow));
                 break;
+            case ACTION_CLEAR_CALLS:
+                // Propagate the key to the previous panel
+                return -2;
+
             default:
                 // Parse next action
                 continue;

--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1282,7 +1282,7 @@ call_flow_handle_key(PANEL *panel, int key)
                 break;
             case ACTION_CLEAR_CALLS:
                 // Propagate the key to the previous panel
-                return -2;
+                return -1;
 
             default:
                 // Parse next action
@@ -1338,20 +1338,21 @@ call_flow_help(PANEL *panel)
     // A list of available keys in this window
     mvwprintw(help_win, 8, 2, "Available keys:");
     mvwprintw(help_win, 9, 2, "Esc/Q       Go back to Call list window");
-    mvwprintw(help_win, 10, 2, "Enter       Show current message Raw");
-    mvwprintw(help_win, 11, 2, "F1/h        Show this screen");
-    mvwprintw(help_win, 12, 2, "F2/d        Toggle SDP Address:Port info");
-    mvwprintw(help_win, 13, 2, "F3/m        Toggle RTP arrows display");
-    mvwprintw(help_win, 14, 2, "F4/X        Show call-flow with X-CID/X-Call-ID dialog");
-    mvwprintw(help_win, 15, 2, "F5/s        Toggle compressed view (One address <=> one column");
-    mvwprintw(help_win, 16, 2, "F6/R        Show original call messages in raw mode");
-    mvwprintw(help_win, 17, 2, "F7/c        Cycle between available color modes");
-    mvwprintw(help_win, 18, 2, "F8/C        Turn on/off message syntax highlighting");
-    mvwprintw(help_win, 19, 2, "F9/l        Turn on/off resolved addresses");
-    mvwprintw(help_win, 20, 2, "9/0         Increase/Decrease raw preview size");
-    mvwprintw(help_win, 21, 2, "t           Toggle raw preview display");
-    mvwprintw(help_win, 22, 2, "T           Restore raw preview size");
-    mvwprintw(help_win, 23, 2, "D           Only show SDP messages");
+    mvwprintw(help_win, 10, 2, "F5/Ctrl-L   Leave screen and clear call list");
+    mvwprintw(help_win, 11, 2, "Enter       Show current message Raw");
+    mvwprintw(help_win, 12, 2, "F1/h        Show this screen");
+    mvwprintw(help_win, 13, 2, "F2/d        Toggle SDP Address:Port info");
+    mvwprintw(help_win, 14, 2, "F3/m        Toggle RTP arrows display");
+    mvwprintw(help_win, 15, 2, "F4/X        Show call-flow with X-CID/X-Call-ID dialog");
+    mvwprintw(help_win, 16, 2, "F5/s        Toggle compressed view (One address <=> one column");
+    mvwprintw(help_win, 17, 2, "F6/R        Show original call messages in raw mode");
+    mvwprintw(help_win, 18, 2, "F7/c        Cycle between available color modes");
+    mvwprintw(help_win, 19, 2, "F8/C        Turn on/off message syntax highlighting");
+    mvwprintw(help_win, 20, 2, "F9/l        Turn on/off resolved addresses");
+    mvwprintw(help_win, 21, 2, "9/0         Increase/Decrease raw preview size");
+    mvwprintw(help_win, 22, 2, "t           Toggle raw preview display");
+    mvwprintw(help_win, 23, 2, "T           Restore raw preview size");
+    mvwprintw(help_win, 24, 2, "D           Only show SDP messages");
 
 
     // Press any key to close

--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1282,7 +1282,7 @@ call_flow_handle_key(PANEL *panel, int key)
                 break;
             case ACTION_CLEAR_CALLS:
                 // Propagate the key to the previous panel
-                return -1;
+                return KEY_PROPAGATED;
 
             default:
                 // Parse next action

--- a/src/curses/ui_call_flow.h
+++ b/src/curses/ui_call_flow.h
@@ -336,7 +336,9 @@ call_flow_draw_raw_rtcp(PANEL *panel, rtp_stream_t *rtcp);
  *
  * This function will manage the custom keybindings of the panel. If this
  * function returns -1, the ui manager will check if the pressed key
- * is one of the common ones (like toggle colors and so).
+ * is one of the common ones (like toggle colors and so). If this function
+ * returns -2, the ui manager will destroy the current panel and pass the key
+ * to the previous panel.
  *
  * @param panel Ncurses panel pointer
  * @param key Pressed keycode

--- a/src/curses/ui_call_flow.h
+++ b/src/curses/ui_call_flow.h
@@ -335,10 +335,8 @@ call_flow_draw_raw_rtcp(PANEL *panel, rtp_stream_t *rtcp);
  * @brief Handle Call flow extended key strokes
  *
  * This function will manage the custom keybindings of the panel. If this
- * function returns -1, the ui manager will check if the pressed key
- * is one of the common ones (like toggle colors and so). If this function
- * returns -2, the ui manager will destroy the current panel and pass the key
- * to the previous panel.
+ * function returns -1, the ui manager will destroy the current panel and
+ * pass the key to the previous panel.
  *
  * @param panel Ncurses panel pointer
  * @param key Pressed keycode

--- a/src/curses/ui_call_raw.c
+++ b/src/curses/ui_call_raw.c
@@ -269,7 +269,7 @@ call_raw_handle_key(PANEL *panel, int key)
                 break;
             case ACTION_CLEAR_CALLS:
                 // Propagate the key to the previous panel
-                return -1;
+                return KEY_PROPAGATED;
             default:
                 // Parse next action
                 continue;

--- a/src/curses/ui_call_raw.c
+++ b/src/curses/ui_call_raw.c
@@ -267,6 +267,9 @@ call_raw_handle_key(PANEL *panel, int key)
                     call_raw_set_msg(info->msg);
                 }
                 break;
+            case ACTION_CLEAR_CALLS:
+                // Propagate the key to the previous panel
+                return -2;
             default:
                 // Parse next action
                 continue;

--- a/src/curses/ui_call_raw.c
+++ b/src/curses/ui_call_raw.c
@@ -269,7 +269,7 @@ call_raw_handle_key(PANEL *panel, int key)
                 break;
             case ACTION_CLEAR_CALLS:
                 // Propagate the key to the previous panel
-                return -2;
+                return -1;
             default:
                 // Parse next action
                 continue;

--- a/src/curses/ui_call_raw.h
+++ b/src/curses/ui_call_raw.h
@@ -117,7 +117,10 @@ call_raw_print_msg(PANEL *panel, sip_msg_t *msg);
  *
  * This function will manage the custom keybindings of the panel. If this
  * function returns -1, the ui manager will check if the pressed key
- * is one of the common ones (like toggle colors and so).
+ * is one of the common ones (like toggle colors and so). If this function
+ * returns -2, the ui manager will destroy the current panel and pass the key
+ * to the previous panel.
+
  *
  * @param panel Ncurses panel pointer
  * @param key Pressed keycode

--- a/src/curses/ui_call_raw.h
+++ b/src/curses/ui_call_raw.h
@@ -116,10 +116,8 @@ call_raw_print_msg(PANEL *panel, sip_msg_t *msg);
  * @brief Handle Call Raw key strokes
  *
  * This function will manage the custom keybindings of the panel. If this
- * function returns -1, the ui manager will check if the pressed key
- * is one of the common ones (like toggle colors and so). If this function
- * returns -2, the ui manager will destroy the current panel and pass the key
- * to the previous panel.
+ * function returns -1, the ui manager will destroy the current panel and
+ * pass the key to the previous panel.
 
  *
  * @param panel Ncurses panel pointer

--- a/src/curses/ui_manager.c
+++ b/src/curses/ui_manager.c
@@ -302,6 +302,9 @@ wait_for_input()
     WINDOW *win;
     PANEL *panel;
 
+    int c = ERR;
+    int rekey = 0;
+
     // While there are still panels
     while ((panel = panel_below(NULL))) {
 
@@ -322,16 +325,26 @@ wait_for_input()
         win = panel_window(panel);
         keypad(win, TRUE);
 
-        // Get pressed key
-        int c = wgetch(win);
+        if (rekey == 0) {
+          // Get pressed key
+          c = wgetch(win);
 
-        // Timeout, no key pressed
-        if (c == ERR)
-            continue;
+          // Timeout, no key pressed
+          if (c == ERR)
+              continue;
+        } else {
+          rekey = 0;
+        }
 
         // Check if current panel has custom bindings for that key
-        if ((c = ui_handle_key(ui, c)) == 0) {
+        int ret = ui_handle_key(ui, c);
+        if (ret == 0) {
             // Key has been handled by panel
+            continue;
+        } else if (ret == -2) {
+            // Propagate the key to the previous panel
+            ui_destroy(ui);
+            rekey = 1;
             continue;
         }
 

--- a/src/curses/ui_manager.c
+++ b/src/curses/ui_manager.c
@@ -330,23 +330,24 @@ wait_for_input()
             continue;
 
         // Handle received key
-        int hdl = -1;
-        while (hdl != KEY_HANDLED) {
+        int key = c;
+        while (c != KEY_HANDLED) {
             // Check if current panel has custom bindings for that key
-            hdl = ui_handle_key(ui, c);
+            c = ui_handle_key(ui, c);
 
-            if (hdl == KEY_HANDLED) {
+            if (c == KEY_HANDLED) {
                 // Panel handled this key
                 continue;
-            } else if (hdl == KEY_PROPAGATED) {
+            } else if (c == KEY_PROPAGATED) {
+                // restore the key value
+                c = key;
                 // Destroy current panel
                 ui_destroy(ui);
                 // Try to handle this key with the previus panel
                 ui = ui_find_by_panel(panel_below(NULL));
             } else {
                 // Key not handled by UI nor propagated. Use default handler
-                default_handle_key(ui, c);
-                break;
+                c = default_handle_key(ui, c);
             }
         }
     }
@@ -402,8 +403,8 @@ default_handle_key(ui_t *ui, int key)
         break;
     }
 
-    // Return this is a valid handled key
-    return (action == ERR) ? key : 0;
+    // Consider the key handled at this point
+    return KEY_HANDLED;
 }
 
 void

--- a/src/curses/ui_manager.h
+++ b/src/curses/ui_manager.h
@@ -55,6 +55,10 @@
 #define DIALOG_MAX_WIDTH 100
 #define DIALOG_MIN_WIDTH 40
 
+//! Possible key handler results
+#define KEY_HANDLED      0
+#define KEY_PROPAGATED  -1
+
 //! Shorter declaration of ui structure
 typedef struct ui ui_t;
 

--- a/src/curses/ui_manager.h
+++ b/src/curses/ui_manager.h
@@ -304,7 +304,7 @@ wait_for_input();
 /**
  * @brief Default handler for keys
  *
- * If ui doesn't handle the given key (ui_handle_key returns -1)
+ * If ui doesn't handle the given key (ui_handle_key returns the key value)
  * then the default handler will be invoked
  *
  * @param ui Current displayed UI structure


### PR DESCRIPTION
The motivation of this feature is being able to run an action which is not
handled (or is only partially handled) by the current panel. After
handling the key on the current panel, this is destroyed by the ui_manager
and the key is passed to the previous panel. This can be done recursively until
the last panel is reached.

A clear use case is the ability to invoke ACTION_CLEAR_CALLS action from any of
'call_list', 'call_flow', or 'call_raw' with a single keystroke.