### PR TITLE
Get rid of compile warning for clang and added tags/vim swap files to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ doc/html
 # Tags file
 tags
 TAGS
+
+# Vim swap files
+.*.swp
+.*.swo

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ test-driver
 
 # Ignore Doxygen generated files
 doc/html
+
+# Tags file
+tags
+TAGS

--- a/src/setting.c
+++ b/src/setting.c
@@ -191,7 +191,7 @@ int
 setting_has_value(int id, const char *value)
 {
     setting_t *sett = setting_by_id(id);
-    if (sett && sett->value) {
+    if (sett) {
         return !strcmp(sett->value, value);
     }
 


### PR DESCRIPTION
Get rid of compile warning for clang and added tags/vim swap files to git ignore.

The warning was:

```
    setting.c:194:23: warning: address of array 'sett->value' will always
    evaluate to 'true' [-Wpointer-bool-conversion]
    if (sett && sett->value) {
                 ~~ ~~~~~~^~~~~
                 1 warning generated.
```