### PR TITLE
Rtp arrows

### DIFF
--- a/src/rtp.c
+++ b/src/rtp.c
@@ -201,13 +201,6 @@ rtp_check_packet(packet_t *packet)
         if (!(stream_is_complete(stream))) {
             stream_complete(stream, src);
             stream_set_format(stream, format);
-            // Check if an stream in the opposite direction exists
-            if (!(reverse = rtp_find_call_stream(stream->media->msg->call, stream->dst, stream->src))) {
-                reverse = stream_create(stream->media, stream->src, PACKET_RTP);
-                stream_complete(reverse, stream->dst);
-                stream_set_format(reverse, format);
-                call_add_stream(msg_get_call(stream->media->msg), reverse);
-            }
         }
 
         // Add packet to stream


### PR DESCRIPTION
In some scenarios, usually when both peers of the call are under the same IP address, the RTP ports are swapped on the call flow and they are assigned to the wrong call leg.

I found out that the SDP media parser was not correctly setting the IP, port values to the corresponding streams and it was storing incomplete streams on the call.

Also, in rtp.c, reverse streams were created with the media information of the opposite leg, making the ui_call_flow code believe that the RTP direction was the opposite that it actually was.