### PR TITLE
Use sng_malloc() for rcfile string buffers instead of stack

### DIFF
--- a/src/curses/ui_column_select.c
+++ b/src/curses/ui_column_select.c
@@ -378,9 +378,9 @@ column_select_save_columns(ui_t *ui)
     char *tmpfile  = NULL;
 
     // Use current $SNGREPRC or $HOME/.sngreprc file
-    if (rcfile = getenv("SNGREPRC")) {
-        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
-            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+    if ((rcfile = getenv("SNGREPRC"))) {
+        if ((userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
+            if ((tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
                 sprintf(userconf, "%s", rcfile);
                 sprintf(tmpfile, "%s.old", rcfile);
             } else {
@@ -390,9 +390,9 @@ column_select_save_columns(ui_t *ui)
         } else {
             return;
         }
-    } else if (rcfile = getenv("HOME")) {
-        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
-            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+    } else if ((rcfile = getenv("HOME"))) {
+        if ((userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
+            if ((tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
                 sprintf(userconf, "%s/.sngreprc", rcfile);
                 sprintf(tmpfile, "%s/.sngreprc.old", rcfile);
             } else {

--- a/src/curses/ui_column_select.c
+++ b/src/curses/ui_column_select.c
@@ -374,15 +374,34 @@ column_select_save_columns(ui_t *ui)
     char columnopt[128];
     char line[1024];
     char *rcfile;
-    char userconf[128], tmpfile[128];
+    char *userconf = NULL;
+    char *tmpfile  = NULL;
 
     // Use current $SNGREPRC or $HOME/.sngreprc file
     if (rcfile = getenv("SNGREPRC")) {
-        sprintf(userconf, "%s", rcfile);
-        sprintf(tmpfile, "%s.old", rcfile);
+        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+                sprintf(userconf, "%s", rcfile);
+                sprintf(tmpfile, "%s.old", rcfile);
+            } else {
+                sng_free(userconf);
+                return;
+            }
+        } else {
+            return;
+        }
     } else if (rcfile = getenv("HOME")) {
-        sprintf(userconf, "%s/.sngreprc", rcfile);
-        sprintf(tmpfile, "%s/.sngreprc.old", rcfile);
+        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+                sprintf(userconf, "%s/.sngreprc", rcfile);
+                sprintf(tmpfile, "%s/.sngreprc.old", rcfile);
+            } else {
+                sng_free(userconf);
+                return;
+            }
+        } else {
+            return;
+        }
     } else {
         return;
     }
@@ -396,6 +415,8 @@ column_select_save_columns(ui_t *ui)
     // Create a new user conf file
     if (!(fo = fopen(userconf, "w"))) {
         dialog_run("Unable to open %s: %s", userconf, strerror(errno));
+        sng_free(userconf);
+        sng_free(tmpfile);
         return;
     }
 
@@ -430,6 +451,9 @@ column_select_save_columns(ui_t *ui)
 
     // Show a information dialog
     dialog_run("Column layout successfully saved to %s", userconf);
+
+    sng_free(userconf);
+    sng_free(tmpfile);
 }
 
 

--- a/src/curses/ui_settings.c
+++ b/src/curses/ui_settings.c
@@ -462,9 +462,9 @@ ui_settings_save(ui_t *ui)
     settings_info_t *info = settings_info(ui);
 
     // Use current $SNGREPRC or $HOME/.sngreprc file
-    if (rcfile = getenv("SNGREPRC")) {
-        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
-            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+    if ((rcfile = getenv("SNGREPRC"))) {
+        if ((userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
+            if ((tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
                 sprintf(userconf, "%s", rcfile);
                 sprintf(tmpfile, "%s.old", rcfile);
             } else {
@@ -474,9 +474,9 @@ ui_settings_save(ui_t *ui)
         } else {
             return;
         }
-    } else if (rcfile = getenv("HOME")) {
-        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
-            if (tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+    } else if ((rcfile = getenv("HOME"))) {
+        if ((userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
+            if ((tmpfile = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
                 sprintf(userconf, "%s/.sngreprc", rcfile);
                 sprintf(tmpfile, "%s/.sngreprc.old", rcfile);
             } else {

--- a/src/option.c
+++ b/src/option.c
@@ -50,7 +50,7 @@ int
 init_options()
 {
     // Custom user conf file
-    char userconf[128];
+    char *userconf = NULL;
     char *rcfile;
     char pwd[MAX_SETTING_LEN];
 
@@ -79,8 +79,11 @@ init_options()
     if (rcfile = getenv("SNGREPRC")) {
         read_options(rcfile);
     } else if (rcfile = getenv("HOME")) {
-        sprintf(userconf, "%s/.sngreprc", rcfile);
-        read_options(userconf);
+        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+            sprintf(userconf, "%s/.sngreprc", rcfile);
+            read_options(userconf);
+            sng_free(userconf);
+        }
     }
 
     return 0;

--- a/src/option.c
+++ b/src/option.c
@@ -76,10 +76,10 @@ init_options()
     read_options("/etc/sngreprc");
     read_options("/usr/local/etc/sngreprc");
     // Get user configuration
-    if (rcfile = getenv("SNGREPRC")) {
+    if ((rcfile = getenv("SNGREPRC"))) {
         read_options(rcfile);
-    } else if (rcfile = getenv("HOME")) {
-        if (userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN)) {
+    } else if ((rcfile = getenv("HOME"))) {
+        if ((userconf = sng_malloc(strlen(rcfile) + RCFILE_EXTRA_LEN))) {
             sprintf(userconf, "%s/.sngreprc", rcfile);
             read_options(userconf);
             sng_free(userconf);

--- a/src/setting.h
+++ b/src/setting.h
@@ -45,6 +45,9 @@
 //! Max setting value
 #define MAX_SETTING_LEN   1024
 
+//! Max extra length needed for "/.sngreprc.old"
+#define RCFILE_EXTRA_LEN   16
+
 //! Shorter declarartion of setting_option struct
 typedef struct setting_option setting_t;
 


### PR DESCRIPTION
The ```$HOME``` and now ```$SNGREPRC``` environment variable strings were copied to stack based buffers, unchecked.

This PR switches to using ```sng_malloc()``` instead of stack based buffers for that case.

Works fine in my testing.