### PR TITLE
added -F option to skip loading default config file

### DIFF
--- a/src/option.c
+++ b/src/option.c
@@ -47,7 +47,7 @@ option_opt_t options[1024];
 int optscnt = 0;
 
 int
-init_options()
+init_options(int no_config)
 {
     // Custom user conf file
     char *userconf = NULL;
@@ -71,6 +71,11 @@ init_options()
     set_option_value("cl.column5", "src");
     set_option_value("cl.column6", "dst");
     set_option_value("cl.column7", "state");
+
+	// Done if config file should not be read
+	if(no_config) {
+		return 0;
+	}
 
     // Read options from configuration files
     read_options("/etc/sngreprc");

--- a/src/option.h
+++ b/src/option.h
@@ -74,10 +74,11 @@ struct config_option {
  * This values can be overriden using resources files, either from system dir
  * or user home dir.
  *
+ * @param no_config Do not load config file if set to 1
  * @return 0 in all cases
  */
 int
-init_options();
+init_options(int no_config);
 
 /**
  * @brief Deallocate options memory


### PR DESCRIPTION
- long option: --no-config

This is useful when default config (e.g., ~/.sngreprc) has setting for common usage (e.g., capture only calls), but from time to time one needs to run bare sngrep with options set via command line, without having to relocate the default config.