### PR TITLE
configure.ac: switch to pkg-config to find gnutls.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,9 +106,14 @@ AC_ARG_WITH([gnutls],
 )
 
 AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
+
+    m4_ifdef([PKG_CHECK_MODULES], [
+        PKG_CHECK_MODULES([LIBGNUTLS], [gnutls])
+    ], [
 	AC_CHECK_LIB([gnutls], [gnutls_init], [], [
 	    AC_MSG_ERROR([ You need to have gnutls installed to compile sngrep])
 	])
+    ])
 
 	AC_CHECK_LIB([gcrypt], [gcry_md_map_name], [], [
 	    AC_MSG_ERROR([ You need to have libgcrypt installed to compile sngrep])

--- a/configure.ac
+++ b/configure.ac
@@ -115,10 +115,22 @@ AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
 	])
     ])
 
-	AC_CHECK_LIB([gcrypt], [gcry_md_map_name], [], [
-	    AC_MSG_ERROR([ You need to have libgcrypt installed to compile sngrep])
-	])
+	AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
+	if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
+	    AC_MSG_FAILURE([libgcrypt-config not found in PATH])
+	fi
+	AC_CHECK_LIB(
+		[gcrypt],
+		[gcry_md_map_name],
+		[LIBGCRYPT_CFLAGS="`${LIBGCRYPT_CONFIG} --cflags`"
+		LIBGCRYPT_LIBS="`${LIBGCRYPT_CONFIG} --libs`"
+		],
+		[AC_MSG_ERROR([ You need to have libgcrypt installed to compile sngrep])],
+		[`${LIBGCRYPT_CONFIG} --libs --cflags`]
+		)
 	AC_DEFINE([WITH_GNUTLS],[],[Compile With GnuTLS compatibility])
+	AC_SUBST(LIBGCRYPT_CFLAGS)
+	AC_SUBST(LIBGCRYPT_LIBS)
 ], [])
 
 ####

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,8 +8,8 @@ sngrep_SOURCES+=capture_eep.c
 endif
 if WITH_GNUTLS
 sngrep_SOURCES+=capture_gnutls.c
-sngrep_CFLAGS+=$(LIBGNUTLS_CFLAGS)
-sngrep_LDADD+=$(LIBGNUTLS_LIBS)
+sngrep_CFLAGS+=$(LIBGNUTLS_CFLAGS) $(LIBGCRYPT_CFLAGS)
+sngrep_LDADD+=$(LIBGNUTLS_LIBS) $(LIBGCRYPT_LIBS)
 endif
 if WITH_OPENSSL
 sngrep_SOURCES+=capture_openssl.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -8,6 +8,8 @@ sngrep_SOURCES+=capture_eep.c
 endif
 if WITH_GNUTLS
 sngrep_SOURCES+=capture_gnutls.c
+sngrep_CFLAGS+=$(LIBGNUTLS_CFLAGS)
+sngrep_LDADD+=$(LIBGNUTLS_LIBS)
 endif
 if WITH_OPENSSL
 sngrep_SOURCES+=capture_openssl.c


### PR DESCRIPTION
Like for openssl in patch [1] and for the same reason,
use pkg-config to find gnutls.

gnutls can be linked with :
    -lintl -lgmp -lunistring -lhogweed -lnettle -ltasn1 -lz

Fixes:
http://autobuild.buildroot.net/results/f7f/f7fb42d3742f6f01000a0d181e0c785640284405

[1] 2563b016ae16cb8cd39d7181917699ae82772296

Signed-off-by: Romain Naour <romain.naour@gmail.com>