### PR TITLE
autotools: fix ncurses wchar detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,9 +1,9 @@
 AC_PREREQ([2.59])
 AC_INIT([sngrep], [1.4.3], [kaian@irontec.com], [sngrep], [http://www.irontec.com/])
 AM_INIT_AUTOMAKE([1.9])
-m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 AC_CONFIG_HEADERS([src/config.h])
-AC_CONFIG_MACRO_DIRS([m4])
+m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
+m4_ifdef([AC_CONFIG_MACRO_DIRS], AC_CONFIG_MACRO_DIRS([m4]), m4_include([m4/sngrep.m4]))
 
 AC_COPYRIGHT("Irontec S.L.")
 


### PR DESCRIPTION
Author: Adam Duskett <aduskett@codeblue.com>

Ncurses detection is currently broken in buildroot.

This patch does the following:
 - Add SNGREP_CHECK_SCRIPT to configure.ac which checks for a
   libname, a function in that library, sets a define if found, and
   if not found, moves on to the next part. This is taken from the
   htop configure.ac.

 - Adds SNGREP_CHECK_LIB to configure.ac which checks for a
   library, a function within that library, sets a define if that function
   is found, and if not found, moves on to the next part.
   This is taken from the htop configure.ac

 - Modifies scrollbar.h and ui_panel.h to include <wctypes.h> instead of
   <ncursesw/ncurses.h> if unicode is supported.