### PR TITLE
send EEP packets to localhost by default

### DIFF
--- a/src/setting.c
+++ b/src/setting.c
@@ -76,7 +76,7 @@ setting_t settings[SETTING_COUNT] = {
 #ifdef USE_EEP
     { SETTING_EEP_SEND,           "eep.send",           SETTING_FMT_ENUM,    SETTING_OFF, SETTING_ENUM_ONOFF },
     { SETTING_EEP_SEND_VER,       "eep.send.version",   SETTING_FMT_ENUM,    "3",         SETTING_ENUM_HEPVERSION },
-    { SETTING_EEP_SEND_ADDR,      "eep.send.address",   SETTING_FMT_STRING,  "10.1.1.1",  NULL },
+    { SETTING_EEP_SEND_ADDR,      "eep.send.address",   SETTING_FMT_STRING,  "127.0.0.1",  NULL },
     { SETTING_EEP_SEND_PORT,      "eep.send.port",      SETTING_FMT_NUMBER,  "9060",      NULL },
     { SETTING_EEP_SEND_PASS,      "eep.send.pass",      SETTING_FMT_STRING,  "",          NULL },
     { SETTING_EEP_SEND_ID,        "eep.send.id",        SETTING_FMT_NUMBER,  "2002",      NULL },


### PR DESCRIPTION
Sending packets by default to unknown destination is actually bad idea, lots people don't read documentation and just enable stuff, and then latter complain `omg your app attacking my network`. 

Make it to safe `127.0.0.1` also avoid security implication when you by accident send private packets to unknown machine