### PR TITLE
Fixed Window Resize in Call List and Call Flow

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -136,11 +136,29 @@ call_flow_info(ui_t *ui)
 bool
 call_flow_redraw(ui_t *ui)
 {
+    int maxx, maxy;
+
     // Get panel information
     call_flow_info_t *info = call_flow_info(ui);
+    // Get current screen dimensions
+    getmaxyx(stdscr, maxy, maxx);
+
+    // Change the main window size
+    wresize(ui->win, maxy, maxx);
+
+    // Store new size
+    ui->width = maxx;
+    ui->height = maxy;
+
+    // Calculate available printable area
+    wresize(info->flow_win, maxy - 6, maxx);
+
+    // Force flow redraw
+    call_flow_draw(ui);
 
     // Check if any of the group has changed
-    return call_group_has_changed(info->group);
+    // return call_group_has_changed(info->group);
+    return 0;
 }
 
 int

--- a/src/curses/ui_call_list.c
+++ b/src/curses/ui_call_list.c
@@ -180,7 +180,7 @@ call_list_resize(ui_t *ui)
     ui->height = maxy;
 
     // Calculate available printable area
-    wresize(info->list_win, maxy - 5, maxx - 4);
+    wresize(info->list_win, maxy - 6, maxx); //-4
     // Force list redraw
     call_list_clear(ui);
 


### PR DESCRIPTION
Maybe it requires further fixes for sub windows resizing, but yet it shows correctly the main call list and flow windows