### PR TITLE
fix manpage typo thanks to lintian

### DIFF
--- a/doc/sngrep.8
+++ b/doc/sngrep.8
@@ -87,7 +87,7 @@ in sngrep to manage hash table sizes.
 .TP
 .I -R
 Remove oldest dialog when the capture limit has reached
-Altough not recommended, this can be used to keep sngrep running during long
+Although not recommended, this can be used to keep sngrep running during long
 times with some control over consumed memory.
 
 .TP


### PR DESCRIPTION
> I: sngrep: spelling-error-in-manpage usr/share/man/man8/sngrep.8.gz Altough Although