### PR TITLE
fix LibreSSL support

### DIFF
--- a/src/capture_openssl.c
+++ b/src/capture_openssl.c
@@ -94,7 +94,7 @@ P_hash(const char *digest, unsigned char *dest, int dlen, unsigned char *secret,
 
     // Calculate enough data to fill destination
     while (pending > 0) {
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
         HMAC_CTX hm;
         HMAC_Init(&hm, secret, sslen, md);
         HMAC_Update(&hm, tmpseed, tmpslen);
@@ -495,7 +495,7 @@ tls_process_record(struct SSLConnection *conn, const uint8_t *payload,
                 break;
             case change_cipher_spec:
                 // From now on, this connection will be encrypted using MasterSecret
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
                 if (conn->client_cipher_ctx->cipher && conn->server_cipher_ctx->cipher)
                     conn->encrypted = 1;
 #else
@@ -588,7 +588,7 @@ tls_process_record_handshake(struct SSLConnection *conn, const opaque *fragment,
                 // Decrypt PreMasterKey
                 clientkeyex = (struct ClientKeyExchange *) body;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#if MODSSL_USE_OPENSSL_PRE_1_1_API
                 RSA_private_decrypt(UINT16_INT(clientkeyex->length),
                                     (const unsigned char *) &clientkeyex->exchange_keys,
                                     (unsigned char *) &conn->pre_master_secret,

--- a/src/capture_openssl.h
+++ b/src/capture_openssl.h
@@ -65,6 +65,15 @@
 #define OLD_OPENSSL_VERSION 1
 #endif
 
+/* LibreSSL declares OPENSSL_VERSION_NUMBER == 2.0 but does not include most
+ * changes from OpenSSL >= 1.1 (new functions, macros, deprecations, ...)
+ */
+#if defined(LIBRESSL_VERSION_NUMBER)
+#define MODSSL_USE_OPENSSL_PRE_1_1_API (1)
+#else
+#define MODSSL_USE_OPENSSL_PRE_1_1_API (OPENSSL_VERSION_NUMBER < 0x10100000L)
+#endif
+
 //! Three bytes unsigned integer
 typedef struct uint16 {
     unsigned char x[2];


### PR DESCRIPTION
This is taken from the apache source code.

LibreSSL declares OPENSSL_VERSION_NUMBER == 2.0 but does not include most
changes from OpenSSL >= 1.1.

To work around this:
- check to see if LIBRESSL_VERSION_NUMBER is defined.
- If so, define MODSSL_USE_OPENSSL_PRE_1_1_API.
- Change all checks for OPENSSL_VERSION_NUMBER < 0x10100000L to
  '#if MODSSL_USE_OPENSSL_PRE_1_1_API'

This keeps the code maintainable in the future as well.