### PR TITLE
Add static compilation support through configure

### DIFF
--- a/README
+++ b/README
@@ -24,9 +24,11 @@ Prerequisites
  - libncurses5 - for UI, windows, panels.
  - libpcap - for capturing packets.
  - libssl - (optional) for TLS transport decrypt using OpenSSL and libcrypt
- - gnutls - (optional) for TLS transport decrypt using GnuTLS and libgcrypt
  - libncursesw5 - (optional) for UI, windows, panels (wide-character support)
  - libpcre - (optional) for Perl Compatible regular expressions
+ - gnutls - (optional) for TLS transport decrypt using GnuTLS and libgcrypt
+    - GnuTLS must be compiled with `--without-p11-kit` for `sngrep`
+      to be built with `--enable-static=yes`
 
 On most systems the commands to build will be the standard autotools procedure:
 
@@ -41,7 +43,7 @@ You can pass following flags to ./configure to enable some features
 |--------------------|-------------------------------------------------------------------|
 | `--with-openssl`   | Adds OpenSSL support to parse TLS captured messages (req. libssl) |
 | `--with-gnutls`    | Adds GnuTLS support to parse TLS captured messages (req. gnutls)  |
-|                    |   - GnuTLS without "p11-kit" is required for static compilation   |
+|                    |   - GnuTLS without `p11-kit` is required for static-compile       |
 |                    |                                                                   |
 | `--with-pcre`      | Adds Perl Compatible regular expressions support in regexp fields |
 | `--enable-unicode` | Adds Ncurses UTF-8/Unicode support (req. libncursesw5)            |

--- a/README
+++ b/README
@@ -37,14 +37,18 @@ On most systems the commands to build will be the standard autotools procedure:
 
 You can pass following flags to ./configure to enable some features
 
-| configure flag | Feature |
-| ------------- | ------------- |
-| `--with-openssl` | Adds OpenSSL support to parse TLS captured messages (req. libssl)  |
-| `--with-gnutls` | Adds GnuTLS support to parse TLS captured messages (req. gnutls)  |
-| `--with-pcre`|  Adds Perl Compatible regular expressions support in regexp fields |
-| `--enable-unicode`   | Adds Ncurses UTF-8/Unicode support (req. libncursesw5) |
-| `--enable-ipv6`   | Enable IPv6 packet capture support. |
-| `--enable-eep`   | Enable EEP packet send/receive support. |
+| configure flag     | Feature                                                           |
+|--------------------|-------------------------------------------------------------------|
+| `--with-openssl`   | Adds OpenSSL support to parse TLS captured messages (req. libssl) |
+| `--with-gnutls`    | Adds GnuTLS support to parse TLS captured messages (req. gnutls)  |
+|                    |   - GnuTLS without "p11-kit" is required for static compilation   |
+|                    |                                                                   |
+| `--with-pcre`      | Adds Perl Compatible regular expressions support in regexp fields |
+| `--enable-unicode` | Adds Ncurses UTF-8/Unicode support (req. libncursesw5)            |
+| `--enable-ipv6`    | Enable IPv6 packet capture support.                               |
+| `--enable-eep`     | Enable EEP packet send/receive support.                           |
+| `--enable-static`  | Enable compilation of statically linked binary.                   |
+
 
 You can find [detailed instructions for some distributions](https://github.com/irontec/sngrep/wiki/Building) on wiki.
 

--- a/configure.ac
+++ b/configure.ac
@@ -164,19 +164,35 @@ AC_ARG_WITH([openssl],
 )
 
 AS_IF([test "x$WITH_OPENSSL" == "xyes"], [
-	AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
-	    AC_MSG_ERROR([ GnuTLS and OpenSSL can not be enabled at the same time ])
+  AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
+    AC_MSG_ERROR([ GnuTLS and OpenSSL can not be enabled at the same time ])
 	], [])
-    m4_ifdef([PKG_CHECK_MODULES], [
-        PKG_CHECK_MODULES([SSL], [libssl libcrypto])
-    ], [
-        AC_CHECK_LIB([ssl], [SSL_new], [], [
-           AC_MSG_ERROR([ You need to have libssl installed to compile sngrep])
-        ])
-        AC_CHECK_LIB([crypto], [EVP_get_cipherbyname], [], [
-            AC_MSG_ERROR([ You need to have libcrypto installed to compile sngrep])
-        ])
+
+  if test "$enable_static" = "yes" ; then
+    AC_CHECK_LIB([dl], [dlopen], [], [
+      AC_MSG_ERROR([ You need to have libdl installed to static-compile sngrep.])
     ])
+
+    AC_CHECK_LIB(crypto, EVP_get_cipherbyname, [], [
+      AC_MSG_ERROR([ You need to have libcrypto installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB(ssl, SSL_new, [], [
+      AC_MSG_ERROR([ You need to have libcrypto installed to static-compile sngrep.])
+    ])
+  fi
+
+  m4_ifdef([PKG_CHECK_MODULES], [
+      PKG_CHECK_MODULES([SSL], [libssl libcrypto])
+  ], [
+      AC_CHECK_LIB([ssl], [SSL_new], [], [
+        AC_MSG_ERROR([ You need to have libssl installed to compile sngrep])
+      ])
+      AC_CHECK_LIB([crypto], [EVP_get_cipherbyname], [], [
+        AC_MSG_ERROR([ You need to have libcrypto installed to compile sngrep])
+      ])
+  ])
+
 	AC_DEFINE([WITH_OPENSSL],[],[Compile With Openssl compatibility])
 ], [])
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,15 @@ if test "$enable_debug" = "yes" ; then
     CXXFLAGS="$CXXFLAGS $CFLAGS"
 fi
 
+# static compilation
+AC_ARG_ENABLE(static,
+    AC_HELP_STRING(--enable-static, [Static compilation (Default = no)]),
+    enable_static=$enableval, enable_static=no)
+
+if test "$enable_static" = "yes" ; then
+    CFLAGS="$CFLAGS  -static"
+fi
+
 # Minimum checks for a C program :)
 AC_PROG_CC
 AC_PROG_CXX

--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,18 @@ AC_CHECK_HEADER([pcap.h], [], [
 ])
 
 ####
-#### Ncurses Wide character support
+#### Ncurses support
 ####
+if test "$enable_static" = "yes" ; then
+    AC_CHECK_LIB([tinfo], [_nc_setupterm], [], [
+        AC_MSG_ERROR([ You need to have libtinfo5 installed to staic-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([gpm], [Gpm_GetEvent], [], [
+        AC_MSG_ERROR([ You need to have libgpm2 installed to static-compile sngrep.])
+    ])
+fi
+
 AC_ARG_ENABLE([unicode],
 	AC_HELP_STRING([--enable-unicode], [Enable Ncurses Unicode support]),
 	[AC_SUBST(UNICODE, $enableval)],

--- a/configure.ac
+++ b/configure.ac
@@ -27,6 +27,9 @@ AC_ARG_ENABLE(static,
 
 if test "$enable_static" = "yes" ; then
     CFLAGS="$CFLAGS  -static"
+    AC_SUBST(ENABLE_STATIC, $enableval)
+else
+    AC_SUBST(ENABLE_STATIC, no)
 fi
 
 # Minimum checks for a C program :)
@@ -333,15 +336,16 @@ AS_IF([test "x$enable_logo" == "xyes"], [
 ])
 
 AC_MSG_NOTICE
-AC_MSG_NOTICE(   sngrep configure finished                            	)
-AC_MSG_NOTICE( ====================================================== 	)
-AC_MSG_NOTICE( GnuTLS Support               : ${WITH_GNUTLS}		)
-AC_MSG_NOTICE( OpenSSL Support              : ${WITH_OPENSSL} 			)
-AC_MSG_NOTICE( Unicode Support              : ${UNICODE}  		)
-AC_MSG_NOTICE( Perl Expressions Support     : ${WITH_PCRE}              )
-AC_MSG_NOTICE( IPv6 Support                 : ${USE_IPV6}               )
-AC_MSG_NOTICE( EEP Support                  : ${USE_EEP}               )
-AC_MSG_NOTICE( ====================================================== 	)
+AC_MSG_NOTICE(   sngrep configure finished                            )
+AC_MSG_NOTICE( ====================================================== )
+AC_MSG_NOTICE( GnuTLS Support               : ${WITH_GNUTLS}          )
+AC_MSG_NOTICE( OpenSSL Support              : ${WITH_OPENSSL}         )
+AC_MSG_NOTICE( Unicode Support              : ${UNICODE}              )
+AC_MSG_NOTICE( Perl Expressions Support     : ${WITH_PCRE}            )
+AC_MSG_NOTICE( IPv6 Support                 : ${USE_IPV6}             )
+AC_MSG_NOTICE( EEP Support                  : ${USE_EEP}              )
+AC_MSG_NOTICE( Static Compile               : ${ENABLE_STATIC}        )
+AC_MSG_NOTICE( ====================================================== )
 AC_MSG_NOTICE
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -128,13 +128,66 @@ AC_ARG_WITH([gnutls],
 
 AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
 
-    m4_ifdef([PKG_CHECK_MODULES], [
-        PKG_CHECK_MODULES([LIBGNUTLS], [gnutls])
-    ], [
-	AC_CHECK_LIB([gnutls], [gnutls_init], [], [
-	    AC_MSG_ERROR([ You need to have gnutls installed to compile sngrep])
-	])
+  if test "$enable_static" = "yes" ; then
+
+    echo ''
+    echo ' *******************************************************'
+    echo ' = GnuTLS without "p11-kit" is required static linking ='
+    echo ' *******************************************************'
+    echo ''
+
+    AC_CHECK_LIB([dl], [dlopen], [], [
+      AC_MSG_ERROR([ You need to have libdl installed to static-compile sngrep.])
     ])
+
+    AC_CHECK_LIB([m], [__ieee754_logf], [], [
+      AC_MSG_ERROR([ You need to have libm installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([gpg-error], [gpg_err_code_from_errno], [], [
+      AC_MSG_ERROR([ You need to have libgpg-error installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([gmp], [__gmpz_init], [], [
+      AC_MSG_ERROR([ You need to have libgmp installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([nettle], [nettle_memxor], [], [
+      AC_MSG_ERROR([ You need to have libnettle installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([tasn1], [asn1_create_element], [], [
+      AC_MSG_ERROR([ You need to have libtasn1 installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([hogweed], [nettle_mpz_sizeinbase_256_u], [], [
+      AC_MSG_ERROR([ You need to have libhogweed installed to static-compile sngrep.])
+    ])
+
+    AC_CHECK_LIB([gcrypt], [gcry_md_map_name], [], [
+      AC_MSG_ERROR([ You need to have libgcrypt installed to static-compile sngrep])
+    ])
+
+    AC_CHECK_LIB([idn], [idna_to_ascii_4i], [], [
+      AC_MSG_ERROR([ You need to have libidn installed to static-compile sngrep])
+    ])
+
+    AC_CHECK_LIB([z], [adler32], [], [
+      AC_MSG_ERROR([ You need to have libz installed to static-compile sngrep])
+    ])
+
+    AC_CHECK_LIB([gnutls], [gnutls_init], [], [
+      AC_MSG_ERROR([ You need to have libgnutls without "p11-kit" installed to static-compile sngrep])
+    ])
+  fi
+
+  m4_ifdef([PKG_CHECK_MODULES], [
+      PKG_CHECK_MODULES([LIBGNUTLS], [gnutls])
+    ], [
+    AC_CHECK_LIB([gnutls], [gnutls_init], [], [
+      AC_MSG_ERROR([ You need to have gnutls installed to compile sngrep])
+    ])
+  ])
 
 	AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
 	if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
@@ -255,7 +308,7 @@ AS_IF([test "x$USE_EEP" == "xyes"], [
 ], [])
 
 
-# Conditional Source inclusion 
+# Conditional Source inclusion
 AM_CONDITIONAL([WITH_GNUTLS], [test "x$WITH_GNUTLS" == "xyes"])
 AM_CONDITIONAL([WITH_OPENSSL], [test "x$WITH_OPENSSL" == "xyes"])
 AM_CONDITIONAL([USE_EEP], [test "x$USE_EEP" == "xyes"])


### PR DESCRIPTION
- This pull-request adds static-compilation of `sngrep` via the
  `configure` script by adding required patches to `configure.ac`.

- The patches between 57494dd - b1fde82 primarily introduce
  additional checks for libraries needed for static linking.

- The existing compilation flow _i.e._ `--enable-static=no`
  remains same as before. Checks are primarily added for
  `--enable-static=yes` scenarios.

- All of the following build configurations were tested on Ubuntu
  16.04.4 LTS with successful builds:

    - `--enable-static=yes --with-openssl`
    - `--enable-static=yes --with-gnutls`
    - `--enable-static=yes --with-pcre`
    - `--enable-static=yes --enable-unicode`
    - `--enable-static=yes --enable-ipv6`
    - `--enable-static=yes --enable-eep`

Hope this helps. Thank you.