### PR TITLE
support multiple (comma separated) devices in sngreprc and on cmdline

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -111,10 +111,10 @@ address_from_str(const char *ipport)
     if (!ipport || strlen(ipport) > ADDRESSLEN + 6)
         return ret;
 
-    strncpy(scanipport, ipport, strlen(ipport));
+    strncpy(scanipport, ipport, sizeof(scanipport));
 
     if (sscanf(scanipport, "%[^:]:%d", address, &port) == 2) {
-        strncpy(ret.ip, address, strlen(address));
+        strncpy(ret.ip, address, sizeof(ret.ip));
         ret.port = port;
     }
 

--- a/src/capture_eep.c
+++ b/src/capture_eep.c
@@ -764,11 +764,10 @@ capture_eep_set_server_url(const char *url)
     char urlstr[256];
     char address[256], port[256];
 
-    memset(urlstr, 0, sizeof(urlstr));
     memset(address, 0, sizeof(address));
     memset(port, 0, sizeof(port));
 
-    strncpy(urlstr, url, strlen(url));
+    strncpy(urlstr, url, sizeof(urlstr));
     if (sscanf(urlstr, "%*[^:]:%[^:]:%s", address, port) == 2) {
         setting_set_value(SETTING_EEP_LISTEN, SETTING_ON);
         setting_set_value(SETTING_EEP_LISTEN_ADDR, address);
@@ -784,11 +783,10 @@ capture_eep_set_client_url(const char *url)
     char urlstr[256];
     char address[256], port[256];
 
-    memset(urlstr, 0, sizeof(urlstr));
     memset(address, 0, sizeof(address));
     memset(port, 0, sizeof(port));
 
-    strncpy(urlstr, url, strlen(url));
+    strncpy(urlstr, url, sizeof(urlstr));
     if (sscanf(urlstr, "%*[^:]:%[^:]:%s", address, port) == 2) {
         setting_set_value(SETTING_EEP_SEND, SETTING_ON);
         setting_set_value(SETTING_EEP_SEND_ADDR, address);

--- a/src/curses/ui_filter.c
+++ b/src/curses/ui_filter.c
@@ -447,8 +447,7 @@ filter_method_from_setting(const char *value)
     // If there's a method filter
     if (methods_len) {
         // Copy value into temporal array
-        memset(methods, 0, sizeof(methods));
-        strncpy(methods, value, methods_len);
+        strncpy(methods, value, sizeof(methods));
 
         // Replace all commas with pippes
         while ((comma = strchr(methods, ',')))

--- a/src/main.c
+++ b/src/main.c
@@ -208,7 +208,11 @@ main(int argc, char* argv[])
             case 'V': /* handled before with higher priority options */
                 break;
             case 'd':
-                vector_append(indevices, optarg);
+                optarg = strtok(optarg, ",");
+                while (optarg) {
+                    vector_append(indevices, optarg);
+                    optarg = strtok(NULL, ",");
+                }
                 break;
             case 'I':
                 vector_append(infiles, optarg);
@@ -326,6 +330,13 @@ main(int argc, char* argv[])
     // Initialize EEP if enabled
     capture_eep_init();
 #endif
+
+    // Split device into tokens and add to list of capture devices
+    device = strtok(device, ",");
+    while (device) {
+        vector_append(indevices, device);
+        device = strtok(NULL, ",");
+    }
 
     // If no device or files has been specified in command line, use default
     if (vector_count(indevices) == 0 && vector_count(infiles) == 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -136,6 +136,7 @@ main(int argc, char* argv[])
     int no_interface = 0, quiet = 0, rtp_capture = 0, rotate = 0, no_config = 0;
     vector_t *infiles = vector_create(0, 1);
     vector_t *indevices = vector_create(0, 1);
+    char *token;
 
     // Program options
     static struct option long_options[] = {
@@ -208,10 +209,10 @@ main(int argc, char* argv[])
             case 'V': /* handled before with higher priority options */
                 break;
             case 'd':
-                optarg = strtok(optarg, ",");
-                while (optarg) {
-                    vector_append(indevices, optarg);
-                    optarg = strtok(NULL, ",");
+                token = strtok(optarg, ",");
+                while (token) {
+                    vector_append(indevices, token);
+                    token = strtok(NULL, ",");
                 }
                 break;
             case 'I':
@@ -332,11 +333,13 @@ main(int argc, char* argv[])
 #endif
 
     // Split device into tokens and add to list of capture devices
-    device = strtok(device, ",");
-    while (device) {
-        vector_append(indevices, device);
-        device = strtok(NULL, ",");
+    token = strdup(device);
+    token = strtok(token, ",");
+    while (token) {
+        vector_append(indevices, token);
+        token = strtok(NULL, ",");
     }
+    sng_free(token);
 
     // If no device or files has been specified in command line, use default
     if (vector_count(indevices) == 0 && vector_count(infiles) == 0) {


### PR DESCRIPTION
Here again:

1. the first 2 commits add support for multiple devices in sngrepc and on cmdline.
```
Example (cmdline):
sngrep -d eth0,eth3

Example (sngreprc):
set capture.device eth0,eth3
```

2. the 3rd commit fixes some compiler warnings

Greetings,
Andreas