### PR TITLE
fix compiler warnings (strncpy)

### DIFF
--- a/src/address.c
+++ b/src/address.c
@@ -111,10 +111,10 @@ address_from_str(const char *ipport)
     if (!ipport || strlen(ipport) > ADDRESSLEN + 6)
         return ret;
 
-    strncpy(scanipport, ipport, strlen(ipport));
+    strncpy(scanipport, ipport, sizeof(scanipport));
 
     if (sscanf(scanipport, "%[^:]:%d", address, &port) == 2) {
-        strncpy(ret.ip, address, strlen(address));
+        strncpy(ret.ip, address, sizeof(ret.ip));
         ret.port = port;
     }
 

--- a/src/capture_eep.c
+++ b/src/capture_eep.c
@@ -764,11 +764,10 @@ capture_eep_set_server_url(const char *url)
     char urlstr[256];
     char address[256], port[256];
 
-    memset(urlstr, 0, sizeof(urlstr));
     memset(address, 0, sizeof(address));
     memset(port, 0, sizeof(port));
 
-    strncpy(urlstr, url, strlen(url));
+    strncpy(urlstr, url, sizeof(urlstr));
     if (sscanf(urlstr, "%*[^:]:%[^:]:%s", address, port) == 2) {
         setting_set_value(SETTING_EEP_LISTEN, SETTING_ON);
         setting_set_value(SETTING_EEP_LISTEN_ADDR, address);
@@ -784,11 +783,10 @@ capture_eep_set_client_url(const char *url)
     char urlstr[256];
     char address[256], port[256];
 
-    memset(urlstr, 0, sizeof(urlstr));
     memset(address, 0, sizeof(address));
     memset(port, 0, sizeof(port));
 
-    strncpy(urlstr, url, strlen(url));
+    strncpy(urlstr, url, sizeof(urlstr));
     if (sscanf(urlstr, "%*[^:]:%[^:]:%s", address, port) == 2) {
         setting_set_value(SETTING_EEP_SEND, SETTING_ON);
         setting_set_value(SETTING_EEP_SEND_ADDR, address);

--- a/src/curses/ui_filter.c
+++ b/src/curses/ui_filter.c
@@ -447,8 +447,7 @@ filter_method_from_setting(const char *value)
     // If there's a method filter
     if (methods_len) {
         // Copy value into temporal array
-        memset(methods, 0, sizeof(methods));
-        strncpy(methods, value, methods_len);
+        strncpy(methods, value, sizeof(methods));
 
         // Replace all commas with pippes
         while ((comma = strchr(methods, ',')))


### PR DESCRIPTION
* about using wrong src for bounds in strncpy and removed the then redundant memset calls

Greetings,
Andreas