### PR TITLE
Fix setting LDFLAGS back to sngrep_save_LDFLAGS

### DIFF
--- a/m4/sngrep.m4
+++ b/m4/sngrep.m4
@@ -44,7 +44,7 @@ AC_DEFUN([SNGREP_CHECK_SCRIPT],
          LIBS="$sngrep_config_script $LIBS "
          sngrep_script_success=yes
       ], [])
-      LDFLAGS="$save_LDFLAGS"
+      LDFLAGS="$sngrep_save_LDFLAGS"
    fi
    if test "x$sngrep_script_success" = xno; then
       [$5]


### PR DESCRIPTION
In m4/sngrep.m4, the value of LDFLAGS is temporarily saved to the
sngrep_save_LDFLAGS variable but is then restored to the empty value of
the unset variable save_LDFLAGS, leaving LDFLAGS empty.

Fix this by prefixing save_LDFLAGS as it was apparently intended.