### PR TITLE
Fix building against ncurses with separate tinfo (termcap) library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,10 @@ AS_IF([test "x$enable_unicode" == "xyes"], [
 	AC_CHECK_LIB([menuw], [new_item], [], [
 	    AC_MSG_ERROR([ You need to have ncurses menuw library installed to compile sngrep.])
 	])
+
+	AC_SEARCH_LIBS([keyname], [tinfow], [], [
+	    AC_MSG_ERROR([ You need to have ncurses tinfow library installed to compile sngrep.])
+	])
 	], [
 
 	# Ncurses without wide-character support
@@ -95,6 +99,10 @@ AS_IF([test "x$enable_unicode" == "xyes"], [
 
 	AC_CHECK_LIB([menu], [new_item], [], [
 	    AC_MSG_ERROR([ You need to have ncurses menu library installed to compile sngrep.])
+	])
+
+	AC_SEARCH_LIBS([keyname], [tinfo], [], [
+	    AC_MSG_ERROR([ You need to have ncurses tinfo library installed to compile sngrep.])
 	])
 ])
 


### PR DESCRIPTION
The linker fails to resolve some symbols when libtinfo is installed as a
separate termcap library.

Fix this by checking a prominent symbol in the wide and non-wide cases.