### PR TITLE
Travis-ci:added support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: c
+arch:
+  - amd64
+  - ppc64le
 compiler:
   - clang
   - gcc
@@ -16,3 +19,4 @@ branches:
   only:
     - master
     - travis
+    - ppc64le


### PR DESCRIPTION
Hi,
I have added support for ppc64le build on travis-ci in the branch on behalf of IBM. The travis-ci build log can be tracked on the link :https://travis-ci.com/github/sanjaymsh/sngrep/builds/209168580 . I believe it is ready for the final review and merge.
Please have a look on it.

Thanks !!