### PR TITLE
MRCPv2 support

### DIFF
--- a/src/sip.h
+++ b/src/sip.h
@@ -44,6 +44,8 @@
 
 #define MAX_SIP_PAYLOAD 10240
 
+#define MRCP_CHANNEL_ID_LENGTH 64
+
 //! Shorter declaration of sip_call_list structure
 typedef struct sip_call_list sip_call_list_t;
 //! Shorter declaration of sip codes structure
@@ -70,6 +72,36 @@ enum sip_methods {
     SIP_METHOD_BYE,
     SIP_METHOD_ACK,
     SIP_METHOD_PRACK,
+
+    SIP_METHOD_MRCP_SET_PARAMS,
+    SIP_METHOD_MRCP_GET_PARAMS,
+    SIP_METHOD_MRCP_SPEAK,
+    SIP_METHOD_MRCP_STOP,
+    SIP_METHOD_MRCP_PAUSE,
+    SIP_METHOD_MRCP_RESUME,
+    SIP_METHOD_MRCP_BARGE_IN_OCCURRED,
+    SIP_METHOD_MRCP_CONTROL,
+    SIP_METHOD_MRCP_DEFINE_LEXICON,
+    SIP_METHOD_MRCP_DEFINE_GRAMMAR,
+    SIP_METHOD_MRCP_RECOGNIZE,
+    SIP_METHOD_MRCP_INTERPRET,
+    SIP_METHOD_MRCP_GET_RESULT,
+    SIP_METHOD_MRCP_START_INPUT_TIMERS,
+    SIP_METHOD_MRCP_START_PHRASE_ENROLLMENT,
+    SIP_METHOD_MRCP_ENROLLMENT_ROLLBACK,
+    SIP_METHOD_MRCP_END_PHRASE_ENROLLMENT,
+    SIP_METHOD_MRCP_MODIFY_PHRASE,
+    SIP_METHOD_MRCP_DELETE_PHRASE,
+    SIP_METHOD_MRCP_RECORD,
+    SIP_METHOD_MRCP_START_SESSION,
+    SIP_METHOD_MRCP_END_SESSION,
+    SIP_METHOD_MRCP_QUERY_VOICEPRINT,
+    SIP_METHOD_MRCP_DELETE_VOICEPRINT,
+    SIP_METHOD_MRCP_VERIFY,
+    SIP_METHOD_MRCP_VERIFY_FROM_BUFFER,
+    SIP_METHOD_MRCP_VERIFY_ROLLBACK,
+    SIP_METHOD_MRCP_CLEAR_BUFFER,
+    SIP_METHOD_MRCP_GET_INTERMEDIATE_RESULT,
 };
 
 //! Return values for sip_validate_packet
@@ -130,6 +162,9 @@ struct sip_call_list {
     //! Call-Ids hash table
     htable_t *callids;
 
+    //! MRCP channelids hash table
+    htable_t *mrcp_channelids;
+
     // Max call limit
     int limit;
     //! Only store dialogs starting with INVITE
@@ -161,6 +196,11 @@ struct sip_call_list {
     regex_t reg_body;
     regex_t reg_reason;
     regex_t reg_warning;
+
+    regex_t reg_mrcp_req;
+    regex_t reg_mrcp_res;
+    regex_t reg_mrcp_evt;
+    regex_t reg_mrcp_channelid;
 };
 
 /**
@@ -186,9 +226,9 @@ sip_deinit();
  *
  * @param payload SIP message payload
  * @param callid Character array to store callid
- * @return callid parsed from Call-ID header
+ * @return 1 on success
  */
-char *
+int
 sip_get_callid(const char* payload, char *callid);
 
 /**
@@ -319,6 +359,15 @@ sip_find_by_index(int index);
 sip_call_t *
 sip_find_by_callid(const char *callid);
 
+/**
+ * @brief Find a call structure in calls linked list given an MRCP channel-identifier
+ *
+ * @param channelid
+ * @return pointer to the sip_call structure found or NULL
+ */
+sip_call_t *
+sip_find_by_mrcp_channelid(const char *channelid);
+
 
 /**
  * @brief Parse extra fields only for dialogs strarting with invite
@@ -368,6 +417,18 @@ sip_calls_rotate();
  */
 int
 sip_get_msg_reqresp(sip_msg_t *msg, const u_char *payload);
+
+/**
+ * @brief Get MRCP message Request/Event/Response
+ *
+ * Parse Payload to get MRCP Request/Event/Response
+ *
+ * @param msg SIP Message to be parsed
+ * @return numeric representation of Request/ResponseCode
+ */
+int
+sip_get_msg_reqresp_for_mrcp(sip_msg_t *msg, const u_char *payload);
+
 
 /**
  * @brief Get full Response code (including text)
@@ -493,5 +554,7 @@ sip_sort_list();
 
 void
 sip_list_sorter(vector_t *vector, void *item);
+
+void sip_remove_mrcp_channelid(char *channelid);
 
 #endif

--- a/src/sip_call.c
+++ b/src/sip_call.c
@@ -59,6 +59,9 @@ call_create(char *callid, char *xcallid)
     // Create an empty vector to store x-calls
     call->xcalls = vector_create(0, 1);
 
+    // Create an empty vector to store mrcp_channelids 
+    call->mrcp_channelids = vector_create(0, 1);
+
     // Initialize call filter status
     call->filtered = -1;
 
@@ -80,6 +83,16 @@ call_destroy(sip_call_t *call)
     vector_destroy(call->rtp_packets);
     // Remove all xcalls
     vector_destroy(call->xcalls);
+
+    // Remove all MRCP channel-identifiers
+    char *channelid;
+    vector_iter_t it = vector_iterator(call->mrcp_channelids);
+    while ((channelid = vector_iterator_next(&it))) {
+        sip_remove_mrcp_channelid(channelid);
+        sng_free(channelid);
+    }
+    vector_destroy(call->mrcp_channelids);
+
     // Deallocate call memory
     sng_free(call->callid);
     sng_free(call->xcallid);

--- a/src/sip_call.h
+++ b/src/sip_call.h
@@ -80,6 +80,8 @@ struct sip_call {
     int warning;
     //! List of calls with with this call as X-Call-Id
     vector_t *xcalls;
+    //! List of MRCP channel-identifiers
+    vector_t *mrcp_channelids;
     //! Cseq from invite startint the call
     uint32_t invitecseq;
     //! List of messages of this call (sip_msg_t*)


### PR DESCRIPTION
Hi, 
I have implemented MRCPv2 support.  
I read https://github.com/irontec/sngrep/issues/254 but didn't like the approach of treating MRCP messages as an rtp_stream.
Instead I adjusted MRCP messages to be handled as SIP messages and based on the channel-identifier returned by the server in its SDP, to add the MRCP messages to the corresponding SIP call.
I have tested and could not find problems using both the offline mode and the live mode with thousands of calls.

(but there are some things that don't work yet like not being able to save the MRCP messages to file).

I'm attaching a sample capture file with MRCP with one session for Speech Synthesis and another for Speech Recognition in case you need them.
[mrcp.pcap.gz](https://github.com/irontec/sngrep/files/5982013/mrcp.pcap.gz)

