### PR TITLE
remove OpenBSD workaround that doesn't work

### DIFF
--- a/src/capture.h
+++ b/src/capture.h
@@ -48,15 +48,6 @@
 #define _BSD_SOURCE 1
 #endif
 
-/* Old versions of libpcap in OpenBSD use <net/bpf.h>
- * which actually defines timestamps as bpf_timeval instead
- * of simple timeval. This no longer happens in newest libpcap
- * versions, where header packets have timestamps in timeval
- * structs */
-#if defined (__OpenBSD__) && defined(_NET_BPF_H_)
-#define timeval bpf_timeval
-#endif
-
 #if defined(BSD) || defined (__OpenBSD__) || defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/socket.h>


### PR DESCRIPTION
This isn't really "old libpcap", it's a local OpenBSD change to make pcap files MI. Upstream libpcap does this differently by passing timevals around directly, and just converting in the file load/save routines instead. It's incorrect because the struct members are different sizes (64-bit for timeval.tv_sec, 32 for bpf_timeval.tv_sec).