### PR TITLE
repair msg_get_time for OpenBSD

### DIFF
--- a/src/sip_msg.c
+++ b/src/sip_msg.c
@@ -108,8 +108,10 @@ msg_get_time(sip_msg_t *msg) {
     struct timeval t = { };
     frame_t *frame;
 
-    if (msg && (frame = vector_first(msg->packet->frames)))
-        return frame->header->ts;
+    if (msg && (frame = vector_first(msg->packet->frames))) {
+        t.tv_sec = frame->header->ts.tv_sec;
+        t.tv_usec = frame->header->ts.tv_usec;
+    }
     return t;
 }
 


### PR DESCRIPTION
msg_get_time() returns timevals obtained from libpcap directly, but in OpenBSD these are really bpf_timeval. Copy the struct members so the standard timeval manipulation functions can operate on them. Fixes hard loop when viewing INVITEs.