### PR TITLE
ui: improve Extended callflow for B-leg dialogs

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1110,7 +1110,7 @@ call_flow_handle_key(ui_t *ui, int key)
     int raw_width, height, width;
     call_flow_info_t *info = call_flow_info(ui);
     ui_t *next_ui;
-    sip_call_t *call = NULL;
+    sip_call_t *call = NULL, *xcall = NULL;
     int rnpag_steps = setting_get_intvalue(SETTING_CF_SCROLLSTEP);
     int action = -1;
 
@@ -1153,8 +1153,17 @@ call_flow_handle_key(ui_t *ui, int key)
                 werase(ui->win);
                 if (call_group_count(info->group) == 1) {
                     call = vector_first(info->group->calls);
-                    call_group_add_calls(info->group, call->xcalls);
-                    info->group->callid = call->callid;
+                    if (call->xcallid != NULL && strlen(call->xcallid)) {
+                        if ((xcall = sip_find_by_callid(call->xcallid))) {
+                            call_group_del(info->group, call);
+                            call_group_add(info->group, xcall);
+                            call_group_add_calls(info->group, xcall->xcalls);
+                            info->group->callid = xcall->callid;
+                        }
+                    } else {
+                        call_group_add_calls(info->group, call->xcalls);
+                        info->group->callid = call->callid;
+                    }
                 } else {
                     call = vector_first(info->group->calls);
                     vector_clear(info->group->calls);

--- a/src/curses/ui_call_list.c
+++ b/src/curses/ui_call_list.c
@@ -563,7 +563,7 @@ call_list_handle_key(ui_t *ui, int key)
     ui_t *next_ui;
     sip_call_group_t *group;
     int action = -1;
-    sip_call_t *call;
+    sip_call_t *call, *xcall;
     sip_sort_t sort;
 
     // Sanity check, this should not happen
@@ -632,8 +632,17 @@ call_list_handle_key(ui_t *ui, int key)
                 // Add xcall to the group
                 if (action == ACTION_SHOW_FLOW_EX) {
                     call = vector_item(info->dcalls, info->cur_call);
-                    call_group_add_calls(group, call->xcalls);
-                    group->callid = call->callid;
+                    if (call->xcallid != NULL && strlen(call->xcallid)) {
+                        if ((xcall = sip_find_by_callid(call->xcallid))) {
+                            call_group_del(group, call);
+                            call_group_add(group, xcall);
+                            call_group_add_calls(group, xcall->xcalls);
+                            group->callid = xcall->callid;
+                        }
+                    } else {
+                        call_group_add_calls(group, call->xcalls);
+                        group->callid = call->callid;
+                    }
                 }
 
                 if (action == ACTION_SHOW_RAW) {


### PR DESCRIPTION
Improve Call List and Call Flow screens so when Extended Flow keybinding is pressed on a call with X-Call-Id information (B-leg dialog), the original call is displayed (with all its B-leg dialogs) insted of the original B-leg.

This Commit is authored by Giovanni Maruzzelli in #352