### PR TITLE
aliasport feature now could match IP:PORT as well as IP only aliases.…

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1391,9 +1391,7 @@ call_flow_column_add(ui_t *ui, const char *callid, address_t addr)
     vector_append(column->callids, (void*)callid);
     column->addr = addr;
     if (setting_enabled(SETTING_ALIAS_PORT)) {
-        char addr_port[1024];
-        sprintf(addr_port, "%s:%d", addr.ip, addr.port);
-        strcpy(column->alias, get_alias_value(addr_port));
+        strcpy(column->alias, get_alias_value_vs_port(addr.ip, addr.port));
     } else {
         strcpy(column->alias, get_alias_value(addr.ip));
     }
@@ -1417,10 +1415,8 @@ call_flow_column_get(ui_t *ui, const char *callid, address_t addr)
     match_port = addr.port != 0;
 
     // Get alias value for given address
-    if (setting_enabled(SETTING_ALIAS_PORT)) {
-        char addr_port[1024];
-        sprintf(addr_port, "%s:%d", addr.ip, addr.port);
-        alias = get_alias_value(addr_port);
+    if (setting_enabled(SETTING_ALIAS_PORT) && match_port) {
+        alias = get_alias_value_vs_port(addr.ip, addr.port);
     } else {
         alias = get_alias_value(addr.ip);
     }

--- a/src/option.c
+++ b/src/option.c
@@ -195,6 +195,29 @@ set_alias_value(const char *address, const char *alias)
 }
 
 const char *
+get_alias_value_vs_port(const char *address, uint16_t port)
+{
+    if (!address)
+        return NULL;
+
+    int i;
+    const char * rc = NULL;
+
+    char *addr_port = sng_malloc(ADDRESSLEN + 10);
+    sprintf(addr_port, "%s:%d", address, port);
+    for (i = 0; i < optscnt; i++) {
+        if (options[i].type != ALIAS)
+            continue;
+        if (!strcmp(options[i].opt, addr_port) || !strcmp(options[i].opt, address)) {
+            sng_free(addr_port);
+            return options[i].value;
+        }
+    }
+
+    return address;
+}
+
+const char *
 get_alias_value(const char *address)
 {
     int i;

--- a/src/option.h
+++ b/src/option.h
@@ -43,6 +43,8 @@
 #ifndef __SNGREP_CONFIG_H
 #define __SNGREP_CONFIG_H
 
+#include <stdint.h>
+
 //! Shorter declaration of config_option struct
 typedef struct config_option option_opt_t;
 
@@ -157,5 +159,14 @@ set_alias_value(const char *address, const char *alias);
 const char *
 get_alias_value(const char *address);
 
+/**
+ * @brief Get alias for a given address and port (string)
+ *
+ * @param address IP Address
+ * @param port port
+ * @return configured alias or address if alias not found
+ */
+const char *
+get_alias_value_vs_port(const char *address, uint16_t port);
 
 #endif


### PR DESCRIPTION
This commit allows to assign alias independent of port number.
During alias pick "IP:PORT" will be checked first and then "IP" only.

For configuration like this

set aliasport on
alias 1.2.3.4:5060 proxy1
alias 1.2.3.4 proxy2

all tuples with 1.2.3.4 address except with port 5060 will be shown as "proxy2" and only 5060 will be shown as "proxy1"