### PR TITLE
always use "%s"-style format for printf()-style functions

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -571,9 +571,9 @@ call_flow_draw_message(ui_t *ui, call_flow_arrow_t *arrow, int cline)
                     media->address.port,
                     media_get_prefered_format(media));
             if (arrow->dir == CF_ARROW_SPIRAL) {
-                mvwprintw(flow_win, cline + 1, startpos + 5, mediastr);
+                mvwprintw(flow_win, cline + 1, startpos + 5, "%s", mediastr);
             } else {
-                mvwprintw(flow_win, cline + 1, startpos + distance / 2 - strlen(mediastr) / 2 + 2, mediastr);
+                mvwprintw(flow_win, cline + 1, startpos + distance / 2 - strlen(mediastr) / 2 + 2, "%s", mediastr);
             }
             cline++;
             aline++;

--- a/src/curses/ui_manager.c
+++ b/src/curses/ui_manager.c
@@ -665,7 +665,7 @@ dialog_confirm(const char *title, const char *text, const char *options)
     curs = curs_set(0);
 
     // Set the window title
-    mvwprintw(dialog_win, 1, (width - strlen(title)) / 2, title);
+    mvwprintw(dialog_win, 1, (width - strlen(title)) / 2, "%s", title);
 
     // Write border and boxes around the window
     wattron(dialog_win, COLOR_PAIR(CP_BLUE_ON_DEF));

--- a/src/curses/ui_msg_diff.c
+++ b/src/curses/ui_msg_diff.c
@@ -187,7 +187,7 @@ msg_diff_draw_message(WINDOW *win, sip_msg_t *msg, char *highlight)
     getmaxyx(win, height, width);
 
     wattron(win, A_BOLD);
-    mvwprintw(win, 0, 0, sip_get_msg_header(msg, header));
+    mvwprintw(win, 0, 0, "%s", sip_get_msg_header(msg, header));
     wattroff(win, A_BOLD);
 
     // Print msg payload


### PR DESCRIPTION
`ncuses-6.3` added printf-style function attributes and now makes
it easier to catch cases when user input is used in palce of format
string when built with CFLAGS=-Werror=format-security:

    curses/ui_msg_diff.c: In function 'msg_diff_draw_message':
    curses/ui_msg_diff.c:190:5: error: format not a string literal and no format arguments [-Werror=format-security]
      190 |     mvwprintw(win, 0, 0, sip_get_msg_header(msg, header));
          |     ^~~~~~~~~

Let's wrap all the missing places with "%s" format.