### PR TITLE
src/capture_openssl.h: fix build with libressl >= 3.5.0

### DIFF
--- a/src/capture_openssl.h
+++ b/src/capture_openssl.h
@@ -67,10 +67,11 @@
 #endif
 
 /* LibreSSL declares OPENSSL_VERSION_NUMBER == 2.0 but does not include most
- * changes from OpenSSL >= 1.1 (new functions, macros, deprecations, ...)
+ * changes from OpenSSL >= 1.1 (new functions, macros, deprecations, ...) until
+ * version 3.5.0
  */
 #if defined(LIBRESSL_VERSION_NUMBER)
-#define MODSSL_USE_OPENSSL_PRE_1_1_API (1)
+#define MODSSL_USE_OPENSSL_PRE_1_1_API (LIBRESSL_VERSION_NUMBER < 0x30500000L)
 #else
 #define MODSSL_USE_OPENSSL_PRE_1_1_API (OPENSSL_VERSION_NUMBER < 0x10100000L)
 #endif


### PR DESCRIPTION
Fix the following build failure with libressl >= 3.5.0:

```
capture_openssl.c: In function 'P_hash':
capture_openssl.c:101:18: error: storage size of 'hm' isn't known
  101 |         HMAC_CTX hm;
      |                  ^~
```

Fixes:
 - http://autobuild.buildroot.org/results/f1e8cdb3ac35a30055ab79d41e6cc038e5339c37

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>