### PR TITLE
check message element exists before strchr and null terminate value

### DIFF
--- a/src/sip_msg.c
+++ b/src/sip_msg.c
@@ -145,13 +145,15 @@ msg_get_attribute(sip_msg_t *msg, int id, char *value)
             sprintf(value, "%.*s", SIP_ATTR_MAXLEN, msg->sip_to);
             break;
         case SIP_ATTR_SIPFROMUSER:
-            if ((ar = strchr(msg->sip_from, '@'))) {
+            if (msg->sip_from && (ar = strchr(msg->sip_from, '@'))) {
                 strncpy(value, msg->sip_from, ar - msg->sip_from);
+                value[ar - msg->sip_from] = '\0';
             }
             break;
         case SIP_ATTR_SIPTOUSER:
-            if ((ar = strchr(msg->sip_to, '@'))) {
+            if (msg->sip_to && (ar = strchr(msg->sip_to, '@'))) {
                 strncpy(value, msg->sip_to, ar - msg->sip_to);
+                value[ar - msg->sip_to] = '\0';
             }
             break;
         case SIP_ATTR_DATE:


### PR DESCRIPTION
This resolves an issue I faced trying to access SIP_ATTR_SIPFROMUSER and SIP_ATTR_SIPTOUSER.  Some instances of `msg->sip_from` were NULL and crashed, others were not null terminated and caused incorrect output.  This patch attempts to resolve both.

There is still a potential issue if the size of `value` is smaller than the string being copied, but that is an issue for all attributes.