### PR TITLE
fix recvfrom() call in capture_eep_receive_v3()

### DIFF
--- a/src/capture_eep.c
+++ b/src/capture_eep.c
@@ -595,8 +595,8 @@ capture_eep_receive_v2()
     //! New created packet pointer
     packet_t *pkt;
     //! EEP client data
-    struct sockaddr eep_client;
-    socklen_t eep_client_len;
+    struct sockaddr_storage eep_client;
+    socklen_t eep_client_len=sizeof(eep_client);
     struct hep_hdr hdr;
     struct hep_timehdr hep_time;
     struct hep_iphdr hep_ipheader;
@@ -611,7 +611,7 @@ capture_eep_receive_v2()
     memset(buffer, 0, MAX_CAPTURE_LEN);
 
     /* Receive EEP generic header */
-    if (recvfrom(eep_cfg.server_sock, buffer, MAX_CAPTURE_LEN, 0, &eep_client, &eep_client_len) == -1)
+    if (recvfrom(eep_cfg.server_sock, buffer, MAX_CAPTURE_LEN, 0, (struct sockaddr*)&eep_client, &eep_client_len) == -1)
         return NULL;
 
     /* Copy initial bytes to HEPv2 header */
@@ -716,8 +716,8 @@ capture_eep_receive_v3(const u_char *pkt, uint32_t size)
     //! Source and Destination Address
     address_t src, dst;
     //! EEP client data
-    struct sockaddr eep_client;
-    socklen_t eep_client_len;
+    struct sockaddr_storage eep_client;
+    socklen_t eep_client_len=sizeof(eep_client);
     //! Packet header
     struct pcap_pkthdr header;
     //! New created packet pointer
@@ -728,7 +728,7 @@ capture_eep_receive_v3(const u_char *pkt, uint32_t size)
 
     if(!pkt) {
         /* Receive EEP generic header */
-        if (recvfrom(eep_cfg.server_sock, buffer, MAX_CAPTURE_LEN, 0, &eep_client, &eep_client_len) == -1)
+        if (recvfrom(eep_cfg.server_sock, buffer, MAX_CAPTURE_LEN, 0, (struct sockaddr*)&eep_client, &eep_client_len) == -1)
             return NULL;
     } else {
         memcpy(&buffer, pkt, size);


### PR DESCRIPTION
- the addrlen parameter must be filled with the size available for src_addr before
  calling recvfrom()
- the size of the src_addr isn't really known before calling recvfrom, it can be
  of different types. So use struct sockaddr_storage for it which is large enough
  to allow different actual address types

This is an issue I found with valgrind when doing a HEP/EEP recieve:
```
==204574== Thread 2:
==204574== Syscall param socketcall.recvfrom(fromlen_in) points to uninitialised byte(s)
==204574==    at 0x4D8ACA2: recvfrom (in /usr/lib64/libpthread-2.33.so)
==204574==    by 0x40887E: capture_eep_receive_v3 (capture_eep.c:731)
==204574==    by 0x408A8D: capture_eep_receive (capture_eep.c:577)
==204574==    by 0x408A8D: capture_eep_receive (capture_eep.c:571)
==204574==    by 0x408A8D: accept_eep_client (capture_eep.c:173)
==204574==    by 0x4D812A4: start_thread (in /usr/lib64/libpthread-2.33.so)
==204574==    by 0x4E99322: clone (in /usr/lib64/libc-2.33.so)
==204574==  Address 0x5c56c2c is on thread 2's stack
==204574==  in frame #1, created by capture_eep_receive_v3 (capture_eep.c:702)
==204574== 
==204574== Syscall param socketcall.recvfrom(fromlen_out) points to uninitialised byte(s)
==204574==    at 0x4D8ACA2: recvfrom (in /usr/lib64/libpthread-2.33.so)
==204574==    by 0x40887E: capture_eep_receive_v3 (capture_eep.c:731)
==204574==    by 0x408A8D: capture_eep_receive (capture_eep.c:577)
==204574==    by 0x408A8D: capture_eep_receive (capture_eep.c:571)
==204574==    by 0x408A8D: accept_eep_client (capture_eep.c:173)
==204574==    by 0x4D812A4: start_thread (in /usr/lib64/libpthread-2.33.so)
==204574==    by 0x4E99322: clone (in /usr/lib64/libc-2.33.so)
==204574==  Address 0x5c56c2c is on thread 2's stack
==204574==  in frame #1, created by capture_eep_receive_v3 (capture_eep.c:702)
```
