### PR TITLE
configure.ac: fix bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ AC_ARG_ENABLE([unicode],
 	[AC_SUBST(UNICODE, no)]
 )
 
-AS_IF([test "x$enable_unicode" == "xyes"], [
+AS_IF([test "x$enable_unicode" = "xyes"], [
 	# Ncurses with wide-character support
 	AC_DEFINE([WITH_UNICODE], [], [Compile With Unicode compatibility])
 
@@ -115,7 +115,7 @@ AC_ARG_WITH([gnutls],
     [AC_SUBST(WITH_GNUTLS, no)]
 )
 
-AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
+AS_IF([test "x$WITH_GNUTLS" = "xyes"], [
 
     m4_ifdef([PKG_CHECK_MODULES], [
         PKG_CHECK_MODULES([LIBGNUTLS], [gnutls])
@@ -152,8 +152,8 @@ AC_ARG_WITH([openssl],
     [AC_SUBST(WITH_OPENSSL, no)]
 )
 
-AS_IF([test "x$WITH_OPENSSL" == "xyes"], [
-	AS_IF([test "x$WITH_GNUTLS" == "xyes"], [
+AS_IF([test "x$WITH_OPENSSL" = "xyes"], [
+	AS_IF([test "x$WITH_GNUTLS" = "xyes"], [
 	    AC_MSG_ERROR([ GnuTLS and OpenSSL can not be enabled at the same time ])
 	], [])
     m4_ifdef([PKG_CHECK_MODULES], [
@@ -179,7 +179,7 @@ AC_ARG_WITH([pcre],
     [AC_SUBST(WITH_PCRE, no)]
 )
 
-AS_IF([test "x$WITH_PCRE" == "xyes"], [
+AS_IF([test "x$WITH_PCRE" = "xyes"], [
 	AC_CHECK_HEADER([pcre.h], [], [
 	    AC_MSG_ERROR([ You need libpcre development files installed to compile with pcre support.])
 	])
@@ -198,8 +198,8 @@ AC_ARG_WITH([pcre2],
     [AC_SUBST(WITH_PCRE2, no)]
 )
 
-AS_IF([test "x$WITH_PCRE2" == "xyes"], [
-    AS_IF([test "x$WITH_PCRE" == "xyes"], [
+AS_IF([test "x$WITH_PCRE2" = "xyes"], [
+    AS_IF([test "x$WITH_PCRE" = "xyes"], [
         AC_MSG_ERROR([libpcre-2 and libpcre-3 can not be enabled at the same time ])
     ], [])
     AC_DEFINE([PCRE2_CODE_UNIT_WIDTH], [8], [Required for including pcre2.h])
@@ -226,7 +226,7 @@ AC_ARG_ENABLE([ipv6],
     [AC_SUBST(USE_IPV6, no)]
 )
 
-AS_IF([test "x$USE_IPV6" == "xyes"], [
+AS_IF([test "x$USE_IPV6" = "xyes"], [
 	AC_CHECK_HEADERS([netinet/in.h netinet/ip6.h], [], [
 	    AC_MSG_ERROR([ You dont seem to have ipv6 support (no ip6.h found).])
 	], [
@@ -251,16 +251,16 @@ AC_ARG_ENABLE([eep],
     [AC_SUBST(USE_EEP, no)]
 )
 
-AS_IF([test "x$USE_EEP" == "xyes"], [
+AS_IF([test "x$USE_EEP" = "xyes"], [
 	AC_DEFINE([USE_EEP],[],[Compile With EEP support])
 ], [])
 
 
 # Conditional Source inclusion
-AM_CONDITIONAL([WITH_PCRE2], [test "x$WITH_PCRE2" == "xyes"])
-AM_CONDITIONAL([WITH_GNUTLS], [test "x$WITH_GNUTLS" == "xyes"])
-AM_CONDITIONAL([WITH_OPENSSL], [test "x$WITH_OPENSSL" == "xyes"])
-AM_CONDITIONAL([USE_EEP], [test "x$USE_EEP" == "xyes"])
+AM_CONDITIONAL([WITH_PCRE2], [test "x$WITH_PCRE2" = "xyes"])
+AM_CONDITIONAL([WITH_GNUTLS], [test "x$WITH_GNUTLS" = "xyes"])
+AM_CONDITIONAL([WITH_OPENSSL], [test "x$WITH_OPENSSL" = "xyes"])
+AM_CONDITIONAL([USE_EEP], [test "x$USE_EEP" = "xyes"])
 
 
 ######################################################################
@@ -270,7 +270,7 @@ AC_ARG_ENABLE(logo,
     [ enable_logo=$enableval],
     [ enable_logo=yes])
 
-AS_IF([test "x$enable_logo" == "xyes"], [
+AS_IF([test "x$enable_logo" = "xyes"], [
     echo ''
     echo ' ██╗██████╗  ██████╗ ███╗   ██╗████████╗███████╗ ██████╗'
     echo ' ██║██╔══██╗██╔═══██╗████╗  ██║╚══██╔══╝██╔════╝██╔════╝'


### PR DESCRIPTION
configure scripts need to be runnable with a POSIX-compliant /bin/sh.

On many (but not all!) systems, /bin/sh is provided by Bash, so errors
like this aren't spotted. Notably Debian defaults to /bin/sh provided
by dash which doesn't tolerate such bashisms as '=='.

This retains compatibility with bash.

Fixes configure warnings/errors like:
```
checking for pcap.h... yes
./configure: 6520: test: xyes: unexpected operator
checking for ncurses.h... yes
checking for initscr in -lncurses... yes
```