### PR TITLE
replace #elifdef with #elif defined()

### DIFF
--- a/src/filter.c
+++ b/src/filter.c
@@ -61,7 +61,7 @@ filter_set(int type, const char *expr)
     // Set new expresion values
     filters[type].expr = (expr) ? strdup(expr) : NULL;
     filters[type].regex = regex;
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     pcre2_code *regex = NULL;
 
     // If we have an expression, check if compiles before changing the filter
@@ -206,7 +206,7 @@ filter_check_expr(filter_t filter, const char *data)
 {
 #ifdef WITH_PCRE
         return pcre_exec(filter.regex, 0, data, strlen(data), 0, 0, 0, 0);
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(filter.regex, NULL);
     int ret = pcre2_match(filter.regex, (PCRE2_SPTR) data, (PCRE2_SIZE) strlen(data), 0, 0, match_data, NULL);
     pcre2_match_data_free(match_data);

--- a/src/filter.h
+++ b/src/filter.h
@@ -43,7 +43,7 @@
 #include "config.h"
 #ifdef WITH_PCRE
 #include <pcre.h>
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
 #include <pcre2.h>
 #else
 #include <regex.h>
@@ -84,7 +84,7 @@ struct filter {
 #ifdef WITH_PCRE
     //! The filter compiled expression
     pcre *regex;
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     //! The filter compiled expression
     pcre2_code *regex;
 #else

--- a/src/sip.c
+++ b/src/sip.c
@@ -832,7 +832,7 @@ sip_set_match_expression(const char *expr, int insensitive, int invert)
     // Check if we have a valid expression
     calls.match_regex = pcre_compile(expr, pflags, &re_err, &err_offset, 0);
     return calls.match_regex == NULL;
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     int re_err = 0;
     PCRE2_SIZE err_offset = 0;
     uint32_t pflags = PCRE2_UNGREEDY | PCRE2_CASELESS;
@@ -875,7 +875,7 @@ sip_check_match_expression(const char *payload)
     }
 
     return 0 == calls.match_invert;
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     pcre2_match_data *match_data = pcre2_match_data_create_from_pattern(calls.match_regex, NULL);
     int ret = pcre2_match(calls.match_regex, (PCRE2_SPTR) payload, (PCRE2_SIZE) strlen(payload), 0, 0, match_data, NULL);
     pcre2_match_data_free(match_data);

--- a/src/sip.h
+++ b/src/sip.h
@@ -37,7 +37,7 @@
 #include <regex.h>
 #ifdef WITH_PCRE
 #include <pcre.h>
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
 #include <pcre2.h>
 #endif
 #include "sip_call.h"
@@ -143,7 +143,7 @@ struct sip_call_list {
 #ifdef WITH_PCRE
     //! Compiled match expression
     pcre *match_regex;
-#elifdef WITH_PCRE2
+#elif defined(WITH_PCRE2)
     //! Compiled match expression
     pcre2_code *match_regex;
 #else


### PR DESCRIPTION
The #elifdef preprocessor directive will only become available with the
upcoming C2x standard.

I do not think that using it already is a good idea, since support for
it is very sparse and no long-term-stable distro has support for it.
Also replacing it with "#elif defined()" doesn't really complicate the code.