### PR TITLE
show dialog count without rotation when using --no-interface

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -445,11 +445,11 @@ main(int argc, char* argv[])
         setbuf(stdout, NULL);
         while(capture_is_running()) {
             if (!quiet)
-                printf("\rDialog count: %d", sip_calls_count());
+                printf("\rDialog count: %d", sip_calls_count_unrotated());
             usleep(500 * 1000);
         }
         if (!quiet)
-            printf("\rDialog count: %d\n", sip_calls_count());
+            printf("\rDialog count: %d\n", sip_calls_count_unrotated());
     }
 
     // Capture deinit

--- a/src/sip.c
+++ b/src/sip.c
@@ -149,6 +149,7 @@ sip_init(int limit, int only_calls, int no_incomplete)
     calls.only_calls = only_calls;
     calls.ignore_incomplete = no_incomplete;
     calls.last_index = 0;
+    calls.call_count_unrotated = 0;
 
     // Create a vector to store calls
     calls.list = vector_create(200, 50);
@@ -438,6 +439,7 @@ sip_check_packet(packet_t *packet)
     if (newcall) {
         // Append this call to the call list
         vector_append(calls.list, call);
+        ++calls.call_count_unrotated;
     }
 
     // Mark the list as changed
@@ -465,6 +467,12 @@ int
 sip_calls_count()
 {
     return vector_count(calls.list);
+}
+
+int
+sip_calls_count_unrotated()
+{
+    return calls.call_count_unrotated;
 }
 
 vector_iter_t

--- a/src/sip.h
+++ b/src/sip.h
@@ -132,6 +132,8 @@ struct sip_call_list {
     //! Call-Ids hash table
     htable_t *callids;
 
+    //! Full count of all captured calls, regardless of rotation
+    int call_count_unrotated;
     // Max call limit
     int limit;
     //! Only store dialogs starting with INVITE
@@ -258,6 +260,14 @@ sip_calls_has_changed();
  */
 int
 sip_calls_count();
+
+/**
+ * @brief Getter for full count of calls since program start
+ *
+ * @return full number of calls since program start, regardless of rotation
+ */
+int
+sip_calls_count_unrotated();
 
 /**
  * @brief Return an iterator of call list


### PR DESCRIPTION
When using --no-interface without --quiet, a dialog counter
is shown and continously updated. Without this patch this
counter just shows the number of calls that are stored in RAM.
When rotation is used, it never shows more calls than the
rotation limit.

Since the --no-interface option is usually just used for
capturing, using it with a small number for rotation (down to 1)
is recommended to not waste RAM. This means the shown value
is useless.

This patch introduces a value call_count_unrotated that can
be queried as part of the stats. This is then used in the
shown dialog count.