### PR TITLE
Implement reading & writing of gzip compressed pcap files

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,7 @@ Prerequisites
  - gnutls - (optional) for TLS transport decrypt using GnuTLS and libgcrypt
  - libncursesw5 - (optional) for UI, windows, panels (wide-character support)
  - libpcre - (optional) for Perl Compatible regular expressions
+ - zlib - (optional) for gzip compressed pcap files
 
 On most systems the commands to build will be the standard autotools procedure:
 
@@ -42,6 +43,7 @@ You can pass following flags to ./configure to enable some features
 | `--with-openssl` | Adds OpenSSL support to parse TLS captured messages (req. libssl)  |
 | `--with-gnutls` | Adds GnuTLS support to parse TLS captured messages (req. gnutls)  |
 | `--with-pcre`|  Adds Perl Compatible regular expressions support in regexp fields |
+| `--with-zlib`|  Enable zlib to support gzip compressed pcap files |
 | `--enable-unicode`   | Adds Ncurses UTF-8/Unicode support (req. libncursesw5) |
 | `--enable-ipv6`   | Enable IPv6 packet capture support. |
 | `--enable-eep`   | Enable EEP packet send/receive support. |

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,9 @@ AC_PROG_EGREP
 AC_LANG(C)
 AM_PROG_CC_C_O
 
+# we might want to use this with zlib for compressed pcap support
+AC_CHECK_FUNCS([fopencookie])
+
 #######################################################################
 # Check for other REQUIRED libraries
 AC_CHECK_LIB([pthread], [pthread_create], [], [
@@ -255,12 +258,33 @@ AS_IF([test "x$USE_EEP" = "xyes"], [
 	AC_DEFINE([USE_EEP],[],[Compile With EEP support])
 ], [])
 
+####
+#### zlib Support
+####
+AC_ARG_WITH([zlib],
+    AS_HELP_STRING([--with-zlib], [Enable zlib to support gzip compressed pcap files]),
+    [AC_SUBST(WITH_ZLIB, $withval)],
+    [AC_SUBST(WITH_ZLIB, no)]
+)
+
+AS_IF([test "x$WITH_ZLIB" = "xyes"], [
+	AC_CHECK_HEADER([zlib.h], [], [
+	    AC_MSG_ERROR([ You need libz header files installed to compile with zlib support.])
+	])
+	AC_CHECK_LIB([z], [gzdopen], [], [
+	    AC_MSG_ERROR([ You need libz library installed to compile with zlib support.])
+	])
+	AC_DEFINE([WITH_ZLIB],[],[Compile With zlib support])
+], [])
+
+
 
 # Conditional Source inclusion
 AM_CONDITIONAL([WITH_PCRE2], [test "x$WITH_PCRE2" = "xyes"])
 AM_CONDITIONAL([WITH_GNUTLS], [test "x$WITH_GNUTLS" = "xyes"])
 AM_CONDITIONAL([WITH_OPENSSL], [test "x$WITH_OPENSSL" = "xyes"])
 AM_CONDITIONAL([USE_EEP], [test "x$USE_EEP" = "xyes"])
+AM_CONDITIONAL([WITH_ZLIB], [test "x$WITH_ZLIB" = "xyes"])
 
 
 ######################################################################
@@ -291,6 +315,7 @@ AC_MSG_NOTICE( Perl Expressions Support     : ${WITH_PCRE}              )
 AC_MSG_NOTICE( Perl Expressions Support (v2): ${WITH_PCRE2}             )
 AC_MSG_NOTICE( IPv6 Support                 : ${USE_IPV6}               )
 AC_MSG_NOTICE( EEP Support                  : ${USE_EEP}               )
+AC_MSG_NOTICE( Zlib Support                 : ${WITH_ZLIB}               )
 AC_MSG_NOTICE( ====================================================== 	)
 AC_MSG_NOTICE
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,11 @@ if WITH_PCRE2
 sngrep_CFLAGS+=$(PCRE2_CFLAGS)
 sngrep_LDADD+=$(PCRE2_LIBS)
 endif
+if WITH_ZLIB
+sngrep_CFLAGS+=$(ZLIB_CFLAGS)
+sngrep_LDADD+=$(ZLIB_LIBS)
+endif
+
 sngrep_SOURCES+=address.c packet.c sip.c sip_call.c sip_msg.c sip_attr.c main.c
 sngrep_SOURCES+=option.c group.c filter.c keybinding.c media.c setting.c rtp.c
 sngrep_SOURCES+=util.c hash.c vector.c curses/ui_panel.c curses/scrollbar.c

--- a/src/curses/ui_manager.c
+++ b/src/curses/ui_manager.c
@@ -192,6 +192,9 @@ ui_wait_for_input()
     // While there are still panels
     while ((panel = panel_below(NULL))) {
 
+        if (was_sigterm_received())
+            return 0;
+
         // Get panel interface structure
         ui = ui_find_by_panel(panel);
 

--- a/src/main.c
+++ b/src/main.c
@@ -327,6 +327,8 @@ main(int argc, char* argv[])
         }
     }
 
+    setup_sigterm_handler();
+
 #if defined(WITH_GNUTLS) || defined(WITH_OPENSSL)
     // Set capture decrypt key file
     capture_set_keyfile(keyfile);
@@ -443,7 +445,7 @@ main(int argc, char* argv[])
         ui_wait_for_input();
     } else {
         setbuf(stdout, NULL);
-        while(capture_is_running()) {
+        while(capture_is_running() && !was_sigterm_received()) {
             if (!quiet)
                 printf("\rDialog count: %d", sip_calls_count_unrotated());
             usleep(500 * 1000);

--- a/src/util.h
+++ b/src/util.h
@@ -99,4 +99,16 @@ timeval_to_delta(struct timeval start, struct timeval end, char *out);
 char *
 strtrim(char *str);
 
+/**
+ * @brief Set up handler for SIGTERM, SIGINT and SIGQUIT
+ */
+void setup_sigterm_handler(void);
+
+/**
+ * @brief Check if SIGTERM, SIGINT or SIGQUIT were received
+ *
+ * @return true if any of the exit signals were received
+ */
+bool was_sigterm_received(void);
+
 #endif /* __SNGREP_UTIL_H */


### PR DESCRIPTION
pcap files can get huge quite fast. But with a verbose text protocol like SIP, 
they have a low information density. So using a lightweight compression
algorithm like deflate/gzip will not just result in much smaller files, but also
often in faster execution because packing is faster than the additional disk IO.
Compression ratios around 90% are common for gzip and SIP pcap files.

gzip is a very common disk format for pcap files. Programs like wireshark directly
support gzip compressed pcap files.

Using just the a pipe output and then piping it through gzip would not result
in the same functionality as the SIGHUP handler then wouldn't work to reopen
a changed file.

So implementing this directly in sngrep yields the best feature set.

-----

libpcap doesn't directly support this, so this is implemented using the
Linux call fopencookie which rereoutes the read,write,seek,close functions.
*BSD seems to have something similar (funopen) which is not implemented in
this patch because I'm not familiar enough with BSD.

gzip detection for read is done by first directly opening the given file
like before. If this fails, we retry with gzip.

gzip detection for write is done by looking at the filename to write to.
If it ends in ".gz" we activate gzip compression.

This currently just works for the commandline option --output because only
there you get to set the filename suffix freely. To make this usable in
the curses gui, the save dialog would have to be extended to allow setting
a .pcap.gz filename extension.

gzip compression must be compiled in to be active. This is done with the new
--with-zlib configure option.