### PR TITLE
ui: import strings.h and config.h, test_input import config.h

### DIFF
--- a/src/curses/ui_manager.c
+++ b/src/curses/ui_manager.c
@@ -26,9 +26,12 @@
  * @brief Source of functions defined in ui_manager.h
  *
  */
+#include "config.h"
+
 #include <ctype.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <math.h>
 #include <stdlib.h>
 #include <locale.h>

--- a/tests/test_input.c
+++ b/tests/test_input.c
@@ -25,6 +25,7 @@
  *
  * Basic input injector for sngrep testing
  */
+#include "config.h"
 
 #include <unistd.h>
 #include <stdio.h>


### PR DESCRIPTION
strings.h required for strncasecmp, fixes an implicit function
declaration

config.h needed for the actual configuration, it sets -D_GNU_SOURCE that
is needed for strsep.