### PR TITLE
fix typo in message, thanks to lintian

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -184,7 +184,7 @@ capture_online(const char *dev)
     }
 
     if (pcap_set_promisc(capinfo->handle, 1) != 0) {
-        fprintf(stderr, "Error setting promiscous mode on %s: %s\n", dev, pcap_geterr(capinfo->handle));
+        fprintf(stderr, "Error setting promiscuous mode on %s: %s\n", dev, pcap_geterr(capinfo->handle));
         return 2;
     }
 


### PR DESCRIPTION
> I: sngrep: spelling-error-in-binary promiscous promiscuous [usr/bin/sngrep]