### PR TITLE
Redefine usage of POSIX signals.

### DIFF
--- a/doc/sngrep.8
+++ b/doc/sngrep.8
@@ -71,7 +71,8 @@ with bpf filters.
 .TP
 .I \-O pcap_dump
 Save all captured packets to a pcap file. This option can be used
-with bpf filters.
+with bpf filters. When receiving a SIGUSR1 signal sngrep will reopen
+the pcap file in order to facilitate pcap file rotation.
 
 .TP
 .I -B buffer

--- a/src/util.c
+++ b/src/util.c
@@ -66,10 +66,9 @@ void setup_sigterm_handler(void)
     if (signal(SIGQUIT, sigterm_handler) == SIG_ERR)
         exit(EXIT_FAILURE);
 
-    // Handle SIGCONT signal, received when parent process has died and
-    // kernel requests us to continue running. This prevents running on
-    // dead ssh connections.
-    if (signal(SIGCONT, sigterm_handler) == SIG_ERR)
+    // Handle SIGHUP signal, received when our controlling terminal is closed.
+    // This prevents running on dead ssh connections.
+    if (signal(SIGHUP, sigterm_handler) == SIG_ERR)
         exit(EXIT_FAILURE);
 }
 


### PR DESCRIPTION
Use signal SIGUSR1 instead of SIGHUP to detect when to rotate the pcap dump file. Use signal SIGHUP instead of SIGCONT to detect when the controlling terminal closed.

This signal usage provides that sngrep closes cleanly when its controlling (SSH) terminal closes.

This pull request resolves #458.