### PR TITLE
Fix warnings related to mismatch of function parameters

### DIFF
--- a/src/capture.h
+++ b/src/capture.h
@@ -313,7 +313,7 @@ capture_packet_parse(packet_t *pkt);
  * @return 0 on success, 1 otherwise
  */
 int
-capture_launch_thread();
+capture_launch_thread(capture_info_t *capinfo);
 
 /**
  * @brief PCAP Capture Thread

--- a/src/main.c
+++ b/src/main.c
@@ -448,7 +448,7 @@ main(int argc, char* argv[])
     }
 
     // Start a capture thread
-    if (capture_launch_thread() != 0) {
+    if (capture_launch_thread(NULL) != 0) {
         ncurses_deinit();
         fprintf(stderr, "Failed to launch capture thread.\n");
         return 1;

--- a/src/sip_msg.c
+++ b/src/sip_msg.c
@@ -33,7 +33,7 @@
 #include "sip.h"
 
 sip_msg_t *
-msg_create()
+msg_create(const char *payload)
 {
     sip_msg_t *msg;
     if (!(msg = sng_malloc(sizeof(sip_msg_t))))

--- a/src/sip_msg.h
+++ b/src/sip_msg.h
@@ -84,7 +84,7 @@ struct sip_msg {
  * @return a new allocated message
  */
 sip_msg_t *
-msg_create();
+msg_create(const char *payload);
 
 /**
  * @brief Destroy a SIP message and free its memory


### PR DESCRIPTION
Compiling latest devel version on MacOS 14.1 resulted in warnings:

```
In file included from capture.c:39:
./capture.h:316:1: warning: a function declaration without a prototype is deprecated in all versions of C and is treated as a zero-parameter prototype in C2x, conflicting with a subsequent definition [-Wdeprecated-non-prototype]
capture_launch_thread();
^
capture.c:1042:1: note: conflicting prototype is here
capture_launch_thread(capture_info_t *capinfo)
^
1 warning generated.
  CC       sngrep-address.o
  CC       sngrep-packet.o
  CC       sngrep-sip.o
sip.c:352:27: warning: passing arguments to 'msg_create' without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
    if (!(msg = msg_create((const char*) payload)))
                          ^
1 warning generated.
```

This PR makes an attempt to fix them, not sure if it is the best way or other values/usage for parameters should be expected.