### PR TITLE
Fixes for Stack Buffer Overflows in SIP Header Processing

### DIFF
--- a/src/sip.c
+++ b/src/sip.c
@@ -238,8 +238,16 @@ sip_get_callid(const char* payload, char *callid)
 
     // Try to get Call-ID from payload
     if (regexec(&calls.reg_callid, payload, 3, pmatch, 0) == 0) {
+        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so;
+
+        // Ensure the copy length does not exceed MAX_CALLID_SIZE - 1
+        if (input_len > MAX_CALLID_SIZE - 1) {
+            input_len = MAX_CALLID_SIZE - 1;
+        }
+
         // Copy the matching part of payload
-        strncpy(callid, payload + pmatch[2].rm_so, (int) pmatch[2].rm_eo - pmatch[2].rm_so);
+        strncpy(callid, payload + pmatch[2].rm_so, input_len);
+        callid[input_len] = '\0';
     }
 
     return callid;
@@ -252,7 +260,15 @@ sip_get_xcallid(const char *payload, char *xcallid)
 
     // Try to get X-Call-ID from payload
     if (regexec(&calls.reg_xcallid, (const char *)payload, 3, pmatch, 0) == 0) {
-        strncpy(xcallid, (const char *)payload +  pmatch[2].rm_so, (int)pmatch[2].rm_eo - pmatch[2].rm_so);
+        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so;
+
+        // Ensure the copy length does not exceed MAX_XCALLID_SIZE - 1
+        if (input_len > MAX_XCALLID_SIZE - 1) {
+            input_len = MAX_XCALLID_SIZE - 1;
+        }
+
+        strncpy(xcallid, (const char *)payload +  pmatch[2].rm_so, input_len);
+        xcallid[input_len] = '\0';
     }
 
     return xcallid;
@@ -328,7 +344,7 @@ sip_check_packet(packet_t *packet)
 {
     sip_msg_t *msg;
     sip_call_t *call;
-    char callid[1024], xcallid[1024];
+    char callid[MAX_CALLID_SIZE], xcallid[MAX_XCALLID_SIZE];
     u_char payload[MAX_SIP_PAYLOAD];
     bool newcall = false;
 

--- a/src/sip.h
+++ b/src/sip.h
@@ -47,6 +47,8 @@
 #define MAX_SIP_PAYLOAD 10240
 #define MAX_CALLID_SIZE 1024
 #define MAX_XCALLID_SIZE 1024
+#define MAX_CONTENT_LENGTH_SIZE 10
+#define MAX_WARNING_SIZE 10
 
 //! Shorter declaration of sip_call_list structure
 typedef struct sip_call_list sip_call_list_t;

--- a/src/sip.h
+++ b/src/sip.h
@@ -45,6 +45,8 @@
 #include "hash.h"
 
 #define MAX_SIP_PAYLOAD 10240
+#define MAX_CALLID_SIZE 1024
+#define MAX_XCALLID_SIZE 1024
 
 //! Shorter declaration of sip_call_list structure
 typedef struct sip_call_list sip_call_list_t;


### PR DESCRIPTION
This pull request addresses critical vulnerabilities in sngrep's SIP header processing, specifically related to stack buffer overflows in "Call-ID", "X-Call-ID", "content-length", and "warning" headers. The fixes introduce bounds checking and ensure string null-termination, mitigating the risk of arbitrary code execution or DoS from malicious SIP messages.