### PR TITLE
Use libgcrypt-config if pkg-config is not available for libcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,22 +128,30 @@ AS_IF([test "x$WITH_GNUTLS" = "xyes"], [
 	])
     ])
 
-	AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
-	if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
-	    AC_MSG_FAILURE([libgcrypt-config not found in PATH])
-	fi
-	AC_CHECK_LIB(
-		[gcrypt],
-		[gcry_md_map_name],
-		[LIBGCRYPT_CFLAGS="`${LIBGCRYPT_CONFIG} --cflags`"
-		LIBGCRYPT_LIBS="`${LIBGCRYPT_CONFIG} --libs`"
-		],
-		[AC_MSG_ERROR([ You need to have libgcrypt installed to compile sngrep])],
-		[`${LIBGCRYPT_CONFIG} --libs --cflags`]
-		)
-	AC_DEFINE([WITH_GNUTLS],[],[Compile With GnuTLS compatibility])
-	AC_SUBST(LIBGCRYPT_CFLAGS)
-	AC_SUBST(LIBGCRYPT_LIBS)
+    m4_ifdef([PKG_CHECK_MODULES], [
+        PKG_CHECK_MODULES([LIBGCRYPT], [libgcrypt])
+    ], [
+        AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
+        if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
+            AC_MSG_FAILURE([libgcrypt-config not found in PATH])
+        else
+            AC_CHECK_LIB(
+                [gcrypt],
+                [gcry_md_map_name],
+                [
+                    LIBGCRYPT_CFLAGS="`${LIBGCRYPT_CONFIG} --cflags`"
+                    LIBGCRYPT_LIBS="`${LIBGCRYPT_CONFIG} --libs`"
+                ], [
+                    AC_MSG_ERROR([ You need to have libgcrypt installed to compile sngrep])
+                ],[
+                    `${LIBGCRYPT_CONFIG} --libs --cflags`
+                ]
+            )
+        fi
+    ])
+    AC_DEFINE([WITH_GNUTLS],[],[Compile With GnuTLS compatibility])
+    AC_SUBST(LIBGCRYPT_CFLAGS)
+    AC_SUBST(LIBGCRYPT_LIBS)
 ], [])
 
 ####


### PR DESCRIPTION
Update configure.ac template to use pkg-config for obtaining libgcrypt flags.

If package config is not available, fallback to libgcrypt-config tool (support for older systems with libgrcypt < 1.8.5)

This fixes #492