### PR TITLE
Cache sorting algorithm with -I option

### DIFF
--- a/src/curses/ui_call_list.c
+++ b/src/curses/ui_call_list.c
@@ -577,9 +577,6 @@ call_list_handle_key(ui_t *ui, int key)
     if (info->menu_active)
         return call_list_handle_menu_key(ui, key);
 
-    // Get window of call list panel
-    WINDOW *list_win = info->list_win;
-
     // Check actions for this key
     while ((action = key_find_action(key, action)) != ERR) {
         // Check if we handle this action

--- a/src/group.h
+++ b/src/group.h
@@ -238,4 +238,12 @@ call_group_get_next_stream(sip_call_group_t *group, rtp_stream_t *stream);
 void
 call_group_msg_sorter(vector_t *vector, void *item);
 
+/**
+ * @brief Create a list of ordered messages for a call group. The list is cached in offline_capture mode
+ * @param callgroup SIP call group structure
+ * @return vector sorted vector
+ */
+vector_t *
+get_ordered_messages(sip_call_group_t *group);
+
 #endif /* __SNGREP_GROUP_H_ */

--- a/src/main.c
+++ b/src/main.c
@@ -121,6 +121,8 @@ version()
            PACKAGE, VERSION);
 }
 
+int offline_capture = 0;
+extern vector_t * oldmessages;
 /**
  * @brief Main function logic
  *
@@ -389,6 +391,7 @@ main(int argc, char* argv[])
         // Try to load file
         if (capture_offline(vector_item(infiles, i)) != 0)
             return 1;
+        offline_capture = 1;
     }
 
     // If we have an input device, load it
@@ -509,6 +512,11 @@ main(int argc, char* argv[])
 
     // Deallocate sip stored messages
     sip_deinit();
+
+    if (offline_capture && oldmessages)
+    {
+        vector_destroy(oldmessages);
+    }
 
     // Leaving!
     return 0;


### PR DESCRIPTION
When using the sngrep -I option with large PCAP files, such as those containing over 1,000 SIP requests,sngrep becomes noticeably sluggish. It can take 5 seconds or more to display the full SIP message sequence, and a similar delay occurs with each keypress when navigating through the call.

Based on my analysis, this performance issue is primarily due to the repeated use of an insert-sorted algorithm, which is executed countless times even though it consistently produces the same result. This leads to unnecessary computation and wasted time.

My commit addresses this inefficiency by caching the result of the initial sorting whenever possible. This avoids redundant iterations and significantly improves performance when working with large capture files.