### PR TITLE
Call flow group message cache

### DIFF
--- a/src/curses/ui_call_list.c
+++ b/src/curses/ui_call_list.c
@@ -577,9 +577,6 @@ call_list_handle_key(ui_t *ui, int key)
     if (info->menu_active)
         return call_list_handle_menu_key(ui, key);
 
-    // Get window of call list panel
-    WINDOW *list_win = info->list_win;
-
     // Check actions for this key
     while ((action = key_find_action(key, action)) != ERR) {
         // Check if we handle this action

--- a/src/group.h
+++ b/src/group.h
@@ -52,6 +52,8 @@ struct sip_call_group {
     char *callid;
     //! Calls array in the group
     vector_t *calls;
+    //! Messages from calls in the group
+    vector_t *msgs;
     //! Color of the last printed call in mode Color-by-Call
     int color;
     //! Only consider SDP messages from Calls


### PR DESCRIPTION
This pull request introduces changes to improve memory management and optimize message handling in SIP call groups. Key updates include adding a `msgs` vector to the `sip_call_group_t` structure, ensuring efficient reuse of message vectors, and improving safety checks in group-related functions.

### Memory Management Improvements:
* Added a `msgs` vector to the `sip_call_group_t` structure to store messages from calls in the group, reducing the need to repeatedly create and destroy temporary message vectors (`src/group.h`).
* Updated `call_group_destroy` to properly free the `msgs` vector when a call group is destroyed (`src/group.c`).

### Message Handling Optimizations:
* Modified `call_group_get_next_msg` and `call_group_get_prev_msg` to reuse the `msgs` vector if it already exists, avoiding redundant vector creation and destruction (`src/group.c`). [[1]](diffhunk://#diff-036c3178a4ac5bbb229a67e04fe7128eb41d19d682aad22a211c674bbe2c230aR241-L247) [[2]](diffhunk://#diff-036c3178a4ac5bbb229a67e04fe7128eb41d19d682aad22a211c674bbe2c230aR278) [[3]](diffhunk://#diff-036c3178a4ac5bbb229a67e04fe7128eb41d19d682aad22a211c674bbe2c230aR288-L284)

### Safety Enhancements:
* Added null checks in `call_group_has_changed` to ensure the function handles empty or uninitialized call groups safely (`src/group.c`).

### Cleanup:
* Removed an unused variable (`list_win`) in `call_list_handle_key` to clean up the code (`src/curses/ui_call_list.c`).

This PR closes #506 