### PR TITLE
rtp: fix duration value in telephony-event is incorrectly converted

### DIFF
--- a/src/rtp.c
+++ b/src/rtp.c
@@ -163,7 +163,7 @@ stream_add_event(rtp_stream_t *stream, packet_t *packet)
     }
 
     event->volume = payload[offset+1] & 0x3F;
-    event->duration = ntohs(payload[offset+2]);
+    event->duration = (payload[offset+2] << 8) + payload[offset+3];
     vector_append(stream->events, event);
 }
 


### PR DESCRIPTION
`event->duration = ntohs(payload[offset+2]);` **<- worng duration  value**
should use
`event->duration = (payload[offset+2] << 8) + payload[offset+3];`
or
`event->duration = ntohs(*(uint16_t*)(payload + offset + 2));`