### PR TITLE
util: expose sng_strncpy() definition

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -57,6 +57,12 @@ sng_free(void *ptr);
 char *
 sng_basename(const char *name);
 
+/*
+ * @brief Wrapper for strncpy
+ */
+char *
+sng_strncpy(char *dst, const char *src, size_t len);
+
 /**
  * @brief Compare two timeval structures
  *


### PR DESCRIPTION
* introduced at df59a5a3d0723c674f7ae53e10376a4ca23742d3 generates build errors:

> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2 -I/usr/include/p11-kit-1      -D_DEFAULT_SOURCE -D_XOPEN_SOURCE=600 -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/reproducible-path/sngrep-1.8.3=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection  -c -o sngrep-address.o `test -f 'address.c' || echo './'`address.c
> address.c: In function ‘address_from_str’:
> address.c:115:5: error: implicit declaration of function ‘sng_strncpy’; did you mean ‘strncpy’? [-Wimplicit-function-declaration]
>   115 |     sng_strncpy(scanipport, ipport, sizeof(scanipport));
>       |     ^~~~~~~~~~~
>       |     strncpy
> make[3]: *** [Makefile:628: sngrep-address.o] Error 1
> make[3]: *** Waiting for unfinished jobs....
> capture_eep.c: In function ‘capture_eep_set_server_url’:
> capture_eep.c:910:5: error: implicit declaration of function ‘sng_strncpy’; did you mean ‘strncpy’? [-Wimplicit-function-declaration]
>   910 |     sng_strncpy(urlstr, url, sizeof(urlstr));
>       |     ^~~~~~~~~~~
>       |     strncpy
> make[3]: *** [Makefile:586: sngrep-capture_eep.o] Error 1