### PR TITLE
sip: Manage active call list properly.

### DIFF
--- a/src/sip.c
+++ b/src/sip.c
@@ -447,13 +447,11 @@ sip_check_packet(packet_t *packet)
         sip_parse_extra_headers(msg, payload);
         // Check if this call should be in active call list
         if (call_is_active(call)) {
-            if (sip_call_is_active(call)) {
+            if (!sip_call_is_active(call)) {
                 vector_append(calls.active, call);
             }
         } else {
-            if (sip_call_is_active(call)) {
-                vector_remove(calls.active, call);
-            }
+            vector_remove(calls.active, call);
         }
     }
 


### PR DESCRIPTION
As the `sip_call_is_active` function is checking the active call list for the given call, it is preventing newly created calls from ever being added to the active list.

Additionally, `vector_remove` returns silently when the given item is not present, so there is no reason to check if the call is in the active list before trying to remove it.