### PR TITLE
Add RTP stream statistics to the Call Flow UI

### DIFF
--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1422,13 +1422,19 @@ call_flow_draw_raw_rtcp(ui_t *ui, rtp_stream_t *stream)
     mvwprintw(raw_win, ++line, 0, "Lost:        %u (%.1f%%)", lost, lostpct);
     mvwprintw(raw_win, ++line, 0, "Out of seq:  %u (%.1f%%)", stats->outoforder, oospct);
     mvwprintw(raw_win, ++line, 0, "Duplicates:  %u", stats->duplicates);
+    mvwprintw(raw_win, ++line, 0, "Timestamp err:%u", stats->wrong_timestamp);
     mvwprintw(raw_win, ++line, 0, "Max Delta:   %.2f ms", stats->max_delta);
+    mvwprintw(raw_win, ++line, 0, "Mean Delta:  %.2f ms", stats->mean_delta);
     mvwprintw(raw_win, ++line, 0, "Max Jitter:  %.2f ms", stats->max_jitter);
+    mvwprintw(raw_win, ++line, 0, "Min Jitter:  %.2f ms", stats->min_jitter);
     mvwprintw(raw_win, ++line, 0, "Mean Jitter: %.2f ms", stats->mean_jitter);
     mvwprintw(raw_win, ++line, 0, "Problems:    %s",
-              (lost || stats->outoforder || stats->duplicates) ? "Yes" : "No");
+              (lost || stats->outoforder || stats->duplicates ||
+               stats->wrong_timestamp) ? "Yes" : "No");
     mvwprintw(raw_win, ++line, 0, "Seq range:   %u -> %u", stats->first_seq, stats->last_seq);
     mvwprintw(raw_win, ++line, 0, "RTP ts:      %u -> %u", stats->first_ts, stats->last_ts);
+    mvwprintw(raw_win, ++line, 0, "Excluded:    marker %u, CN %u, event %u",
+              stats->marker, stats->comfort_noise, stats->telephone_event);
     mvwprintw(raw_win, ++line, 0, "Duration:    %u.%03u s", duration / 1000, duration % 1000);
     mvwprintw(raw_win, ++line, 0, "RFC jitter:  %.1f ts units", stats->jitter);
     if (clock)

--- a/src/curses/ui_call_flow.c
+++ b/src/curses/ui_call_flow.c
@@ -1341,15 +1341,16 @@ call_flow_draw_raw_event(ui_t *ui, rtp_event_t *event)
 int
 call_flow_draw_raw_rtcp(ui_t *ui, rtp_stream_t *stream)
 {
-    /**
-     * TODO This is too experimental to even display it
-     */
-    return 0;
-
     call_flow_info_t *info;
     WINDOW *raw_win;
     int raw_width, raw_height;
     int min_raw_width, fixed_raw_width;
+    rtp_stream_t *rtcp;
+    rtp_stats_t *stats;
+    uint32_t expected, lost, duration, clock;
+    const char *format;
+    float lostpct = 0, oospct = 0;
+    int line = 0;
 
     // Get panel information
     if (!(info = call_flow_info(ui)))
@@ -1395,14 +1396,67 @@ call_flow_draw_raw_rtcp(ui_t *ui, rtp_stream_t *stream)
     mvwvline(ui->win, 1, ui->width - raw_width - 2, ACS_VLINE, ui->height - 2);
     wattroff(ui->win, COLOR_PAIR(CP_BLUE_ON_DEF));
 
-    mvwprintw(raw_win, 0, 0, "============ RTCP Information ============");
-    mvwprintw(raw_win, 2, 0, "Sender's packet count: %d", stream->rtcpinfo.spc);
-    mvwprintw(raw_win, 3, 0, "Fraction Lost: %d / 256", stream->rtcpinfo.flost);
-    mvwprintw(raw_win, 4, 0, "Fraction discarded: %d / 256", stream->rtcpinfo.fdiscard);
-    mvwprintw(raw_win, 6, 0, "MOS - Listening Quality: %.1f", (float) stream->rtcpinfo.mosl / 10);
-    mvwprintw(raw_win, 7, 0, "MOS - Conversational Quality: %.1f", (float) stream->rtcpinfo.mosc / 10);
+    stats = &stream->rtpstats;
+    expected = stream_get_expected_count(stream);
+    lost = stream_get_lost_count(stream);
+    duration = stream_get_duration_ms(stream);
+    clock = stream_get_clock_rate(stream);
+    format = stream_get_format(stream);
+    if (expected)
+        lostpct = (float) lost * 100 / expected;
+    if (stats->received)
+        oospct = (float) stats->outoforder * 100 / stats->received;
 
+    mvwprintw(raw_win, line++, 0, "============ RTP Stream Analysis ============");
+    mvwprintw(raw_win, ++line, 0, "Source:      %s:%u", stream->src.ip, stream->src.port);
+    mvwprintw(raw_win, ++line, 0, "Destination: %s:%u", stream->dst.ip, stream->dst.port);
+    mvwprintw(raw_win, ++line, 0, "Codec:       %s", format ? format : "unknown");
+    mvwprintw(raw_win, ++line, 0, "Payload:     %u", stats->payload_type);
+    mvwprintw(raw_win, ++line, 0, "SSRC:        0x%08x", stats->ssrc);
+    mvwprintw(raw_win, ++line, 0, "Clock rate:  %s", clock ? "" : "unknown");
+    if (clock)
+        mvwprintw(raw_win, line, 13, "%u Hz", clock);
 
+    line++;
+    mvwprintw(raw_win, ++line, 0, "Packets:     %u / %u", stats->received, expected);
+    mvwprintw(raw_win, ++line, 0, "Lost:        %u (%.1f%%)", lost, lostpct);
+    mvwprintw(raw_win, ++line, 0, "Out of seq:  %u (%.1f%%)", stats->outoforder, oospct);
+    mvwprintw(raw_win, ++line, 0, "Duplicates:  %u", stats->duplicates);
+    mvwprintw(raw_win, ++line, 0, "Max Delta:   %.2f ms", stats->max_delta);
+    mvwprintw(raw_win, ++line, 0, "Max Jitter:  %.2f ms", stats->max_jitter);
+    mvwprintw(raw_win, ++line, 0, "Mean Jitter: %.2f ms", stats->mean_jitter);
+    mvwprintw(raw_win, ++line, 0, "Problems:    %s",
+              (lost || stats->outoforder || stats->duplicates) ? "Yes" : "No");
+    mvwprintw(raw_win, ++line, 0, "Seq range:   %u -> %u", stats->first_seq, stats->last_seq);
+    mvwprintw(raw_win, ++line, 0, "RTP ts:      %u -> %u", stats->first_ts, stats->last_ts);
+    mvwprintw(raw_win, ++line, 0, "Duration:    %u.%03u s", duration / 1000, duration % 1000);
+    mvwprintw(raw_win, ++line, 0, "RFC jitter:  %.1f ts units", stats->jitter);
+    if (clock)
+        mvwprintw(raw_win, line, 30, "(%.3f ms)", stats->jitter_ms);
+    mvwprintw(raw_win, ++line, 0, "Active:      %s", stream_is_active(stream) ? "yes" : "no");
+
+    if ((rtcp = rtp_find_related_rtcp_stream(stream)) &&
+        (rtcp->rtcpinfo.reported || rtcp->rtcpinfo.spc ||
+         rtcp->rtcpinfo.flost || rtcp->rtcpinfo.fdiscard ||
+         rtcp->rtcpinfo.mosl || rtcp->rtcpinfo.mosc)) {
+        line += 2;
+        mvwprintw(raw_win, line++, 0, "============ RTCP Information ============");
+        mvwprintw(raw_win, ++line, 0, "Sender packets:      %u", rtcp->rtcpinfo.spc);
+        mvwprintw(raw_win, ++line, 0, "Fraction lost:       %u / 256", rtcp->rtcpinfo.flost);
+        if (rtcp->rtcpinfo.reported) {
+            mvwprintw(raw_win, ++line, 0, "Cumulative lost:     %d", rtcp->rtcpinfo.lost);
+            mvwprintw(raw_win, ++line, 0, "Highest sequence:    %u", rtcp->rtcpinfo.hseq);
+            mvwprintw(raw_win, ++line, 0, "RTCP jitter:         %u", rtcp->rtcpinfo.jitter);
+        }
+        mvwprintw(raw_win, ++line, 0, "Fraction discarded:  %u / 256", rtcp->rtcpinfo.fdiscard);
+        if (rtcp->rtcpinfo.mosl || rtcp->rtcpinfo.mosc) {
+            mvwprintw(raw_win, ++line, 0, "MOS Listening:       %.1f", (float) rtcp->rtcpinfo.mosl / 10);
+            mvwprintw(raw_win, ++line, 0, "MOS Conversational:  %.1f", (float) rtcp->rtcpinfo.mosc / 10);
+        }
+    } else {
+        line += 2;
+        mvwprintw(raw_win, line, 0, "No RTCP information available for this stream");
+    }
 
     // Copy the raw_win contents into the panel
     copywin(raw_win, ui->win, 0, 0, 1, ui->width - raw_width - 1, raw_height, ui->width - 2, 0);

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -31,6 +31,8 @@
 
 #include "config.h"
 #include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
 #include <time.h>
 #include "rtp.h"
 #include "sip.h"
@@ -66,6 +68,202 @@ rtp_encoding_t encodings[] = {
     { 34, "H263/90000", "h263" },
     { 0, NULL, NULL }
 };
+
+static uint16_t
+rtp_read_uint16(const u_char *data)
+{
+    return ((uint16_t) data[0] << 8) | data[1];
+}
+
+static uint32_t
+rtp_read_uint32(const u_char *data)
+{
+    return ((uint32_t) data[0] << 24) | ((uint32_t) data[1] << 16) |
+           ((uint32_t) data[2] << 8) | data[3];
+}
+
+static int32_t
+rtcp_read_lost(const struct rtcp_blk_sr *blk)
+{
+    uint32_t lost = ((uint32_t) blk->plost.pl1 << 16) |
+                    ((uint32_t) blk->plost.pl2 << 8) |
+                    blk->plost.pl3;
+
+    if (lost & 0x800000)
+        lost |= 0xff000000;
+
+    return (int32_t) lost;
+}
+
+static uint32_t
+rtp_encoding_clock_rate(uint32_t code)
+{
+    int i;
+    const char *clock;
+
+    for (i = 0; encodings[i].name; i++) {
+        if (encodings[i].id == code) {
+            if ((clock = strchr(encodings[i].name, '/')))
+                return (uint32_t) atoi(clock + 1);
+            return 0;
+        }
+    }
+
+    return 0;
+}
+
+static uint32_t
+rtp_format_clock_rate(const char *format)
+{
+    const char *clock;
+
+    if (!format || !(clock = strchr(format, '/')))
+        return 0;
+
+    return (uint32_t) atoi(clock + 1);
+}
+
+static uint32_t
+rtp_extended_seq(rtp_stats_t *stats, uint16_t seq)
+{
+    uint32_t cycles = stats->cycles;
+    uint16_t max_seq = stats->max_seq & 0xffff;
+
+    if (stats->initialized && seq < max_seq && max_seq - seq > 30000) {
+        cycles += 0x10000;
+        stats->cycles = cycles;
+    } else if (stats->initialized && seq > max_seq &&
+               seq - max_seq > 30000 && cycles >= 0x10000) {
+        cycles -= 0x10000;
+    }
+
+    return cycles + seq;
+}
+
+static void
+stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
+{
+    u_char *payload = packet_payload(packet);
+    uint32_t size = packet_payloadlen(packet);
+    rtp_stats_t *stats = &stream->rtpstats;
+    struct timeval ptime;
+    uint8_t payload_type;
+    uint16_t seq;
+    uint32_t ts, ssrc, ext_seq, clock;
+    bool accepted = true;
+
+    if (stream->type != PACKET_RTP || size < RTP_HDR_LENGTH)
+        return;
+
+    payload_type = RTP_PAYLOAD_TYPE(*(payload + 1));
+    seq = rtp_read_uint16(payload + 2);
+    ts = rtp_read_uint32(payload + 4);
+    ssrc = rtp_read_uint32(payload + 8);
+    ptime = packet_time(packet);
+
+    if (!stats->initialized) {
+        memset(stats, 0, sizeof(*stats));
+        stats->initialized = true;
+        stats->payload_type = payload_type;
+        stats->ssrc = ssrc;
+        stats->first_seq = seq;
+        stats->last_seq = seq;
+        stats->base_seq = seq;
+        stats->max_seq = seq;
+        stats->first_ts = ts;
+        stats->last_ts = ts;
+        stats->last_time = ptime;
+        stats->received = 1;
+        if ((clock = stream_get_clock_rate(stream))) {
+            stats->transit = ptime.tv_sec * (double) clock +
+                             ptime.tv_usec * (double) clock / 1000000.0 - ts;
+        }
+        return;
+    }
+
+    ext_seq = rtp_extended_seq(stats, seq);
+    stats->received++;
+    stats->payload_type = payload_type;
+    stats->ssrc = ssrc;
+
+    if (ext_seq > stats->max_seq) {
+        if (ext_seq > stats->max_seq + 1)
+            stats->outoforder++;
+        stats->max_seq = ext_seq;
+    } else if (seq == stats->last_seq && ts == stats->last_ts) {
+        stats->duplicates++;
+        stats->outoforder++;
+        accepted = false;
+    } else {
+        stats->outoforder++;
+        accepted = false;
+    }
+
+    if (!accepted) {
+        return;
+    }
+
+    clock = stream_get_clock_rate(stream);
+    {
+        double last_ms = stats->last_time.tv_sec * 1000.0 +
+                         stats->last_time.tv_usec / 1000.0;
+        double current_ms = ptime.tv_sec * 1000.0 + ptime.tv_usec / 1000.0;
+        double delta = current_ms - last_ms;
+
+        if (delta > stats->max_delta)
+            stats->max_delta = delta;
+    }
+
+    if (clock) {
+        double arrival = ptime.tv_sec * (double) clock +
+                         ptime.tv_usec * (double) clock / 1000000.0;
+        double transit = arrival - ts;
+        double d = transit - stats->transit;
+
+        if (d < 0)
+            d = -d;
+        if (stats->received > 1)
+            stats->jitter += (d - stats->jitter) / 16.0;
+        stats->transit = transit;
+        stats->jitter_ms = stats->jitter * 1000 / clock;
+        if (stats->jitter_ms > stats->max_jitter)
+            stats->max_jitter = stats->jitter_ms;
+        stats->jitter_samples++;
+        stats->mean_jitter += (stats->jitter_ms - stats->mean_jitter) /
+                              stats->jitter_samples;
+    }
+
+    stats->last_seq = seq;
+    stats->last_ts = ts;
+    stats->last_time = ptime;
+}
+
+static void
+rtcp_parse_report_block(rtp_stream_t *stream, const u_char *payload)
+{
+    struct rtcp_blk_sr blk;
+
+    memcpy(&blk, payload, sizeof(blk));
+    stream->rtcpinfo.flost = blk.flost;
+    stream->rtcpinfo.lost = rtcp_read_lost(&blk);
+    stream->rtcpinfo.hseq = ntohl(blk.hseq);
+    stream->rtcpinfo.jitter = ntohl(blk.ijitter);
+    stream->rtcpinfo.reported = true;
+}
+
+static void
+rtcp_parse_report_blocks(rtp_stream_t *stream, const u_char *payload, uint32_t size,
+                         uint32_t offset, uint8_t count)
+{
+    uint8_t i;
+
+    for (i = 0; i < count; i++) {
+        if (offset + sizeof(struct rtcp_blk_sr) > size)
+            break;
+        rtcp_parse_report_block(stream, payload + offset);
+        offset += sizeof(struct rtcp_blk_sr);
+    }
+}
 
 rtp_stream_t *
 stream_create(sdp_media_t *media, address_t dst, int type)
@@ -173,6 +371,8 @@ stream_add_packet(rtp_stream_t *stream, packet_t *packet)
     if (stream->pktcnt == 0)
         stream->time = packet_time(packet);
 
+    stream_update_rtp_stats(stream, packet);
+
     stream->lasttm = (int) time(NULL);
     stream->pktcnt++;
 }
@@ -181,6 +381,66 @@ uint32_t
 stream_get_count(rtp_stream_t *stream)
 {
     return stream->pktcnt;
+}
+
+uint32_t
+stream_get_expected_count(rtp_stream_t *stream)
+{
+    rtp_stats_t *stats;
+
+    if (!stream || !(stats = &stream->rtpstats)->initialized)
+        return 0;
+
+    return stats->max_seq - stats->base_seq + 1;
+}
+
+uint32_t
+stream_get_lost_count(rtp_stream_t *stream)
+{
+    rtp_stats_t *stats;
+    uint32_t expected, received;
+
+    if (!stream || !(stats = &stream->rtpstats)->initialized)
+        return 0;
+
+    expected = stream_get_expected_count(stream);
+    received = stats->received - stats->duplicates;
+
+    return (expected > received) ? expected - received : 0;
+}
+
+uint32_t
+stream_get_duration_ms(rtp_stream_t *stream)
+{
+    rtp_stats_t *stats;
+    uint64_t start, end;
+
+    if (!stream || !(stats = &stream->rtpstats)->initialized)
+        return 0;
+
+    start = (uint64_t) stream->time.tv_sec * 1000 + stream->time.tv_usec / 1000;
+    end = (uint64_t) stats->last_time.tv_sec * 1000 + stats->last_time.tv_usec / 1000;
+
+    return (end > start) ? (uint32_t) (end - start) : 0;
+}
+
+uint32_t
+stream_get_clock_rate(rtp_stream_t *stream)
+{
+    const char *fmt;
+    uint32_t rate;
+
+    if (!stream)
+        return 0;
+
+    if ((rate = rtp_encoding_clock_rate(stream->rtpinfo.fmtcode)))
+        return rate;
+
+    if (stream->media &&
+        (fmt = media_get_format(stream->media, stream->rtpinfo.fmtcode)))
+        return rtp_format_clock_rate(fmt);
+
+    return 0;
 }
 
 struct sip_call *
@@ -356,8 +616,15 @@ rtp_check_packet(packet_t *packet)
                         // Get Sender Report header
                         memcpy(&hdr_sr, payload, sizeof(hdr_sr));
                         stream->rtcpinfo.spc = ntohl(hdr_sr.spc);
+                        rtcp_parse_report_blocks(stream, payload, size,
+                                                 sizeof(struct rtcp_hdr_sr),
+                                                 hdr.version & 0x1f);
                         break;
                     case RTCP_HDR_RR:
+                        rtcp_parse_report_blocks(stream, payload, size,
+                                                 sizeof(struct rtcp_hdr_generic) + 4,
+                                                 hdr.version & 0x1f);
+                        break;
                     case RTCP_HDR_SDES:
                     case RTCP_HDR_BYE:
                     case RTCP_HDR_APP:
@@ -541,6 +808,34 @@ rtp_find_call_exact_stream(struct sip_call *call, address_t src, address_t dst)
     }
 
     // Nothing found
+    return NULL;
+}
+
+rtp_stream_t *
+rtp_find_related_rtcp_stream(rtp_stream_t *rtp)
+{
+    rtp_stream_t *stream;
+    sip_call_t *call;
+    vector_iter_t it;
+
+    if (!rtp || rtp->type != PACKET_RTP || !(call = stream_get_call(rtp)))
+        return NULL;
+
+    it = vector_iterator(call->streams);
+    while ((stream = vector_iterator_next(&it))) {
+        if (stream->type != PACKET_RTCP)
+            continue;
+
+        if (address_equals(stream->src, rtp->src) &&
+            address_equals(stream->dst, rtp->dst) &&
+            ((stream->src.port == rtp->src.port + 1 &&
+              stream->dst.port == rtp->dst.port + 1) ||
+             (stream->src.port == rtp->src.port &&
+              stream->dst.port == rtp->dst.port))) {
+            return stream;
+        }
+    }
+
     return NULL;
 }
 

--- a/src/rtp.c
+++ b/src/rtp.c
@@ -123,6 +123,18 @@ rtp_format_clock_rate(const char *format)
     return (uint32_t) atoi(clock + 1);
 }
 
+static bool
+rtp_is_comfort_noise(uint8_t payload_type)
+{
+    return payload_type == 13 || payload_type == 19;
+}
+
+static bool
+rtp_timestamp_in_sequence(rtp_stats_t *stats, uint32_t ts)
+{
+    return (uint32_t) (ts - stats->first_ts) < 0x80000000;
+}
+
 static uint32_t
 rtp_extended_seq(rtp_stats_t *stats, uint16_t seq)
 {
@@ -148,13 +160,16 @@ stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
     rtp_stats_t *stats = &stream->rtpstats;
     struct timeval ptime;
     uint8_t payload_type;
+    bool marker;
     uint16_t seq;
     uint32_t ts, ssrc, ext_seq, clock;
     bool accepted = true;
+    bool regular = true;
 
     if (stream->type != PACKET_RTP || size < RTP_HDR_LENGTH)
         return;
 
+    marker = RTP_MARKER(*(payload + 1));
     payload_type = RTP_PAYLOAD_TYPE(*(payload + 1));
     seq = rtp_read_uint16(payload + 2);
     ts = rtp_read_uint32(payload + 4);
@@ -174,6 +189,12 @@ stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
         stats->last_ts = ts;
         stats->last_time = ptime;
         stats->received = 1;
+        if (marker)
+            stats->marker++;
+        if (rtp_is_comfort_noise(payload_type))
+            stats->comfort_noise++;
+        if (stream->telephone_event)
+            stats->telephone_event++;
         if ((clock = stream_get_clock_rate(stream))) {
             stats->transit = ptime.tv_sec * (double) clock +
                              ptime.tv_usec * (double) clock / 1000000.0 - ts;
@@ -185,6 +206,23 @@ stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
     stats->received++;
     stats->payload_type = payload_type;
     stats->ssrc = ssrc;
+    if (marker) {
+        stats->marker++;
+        regular = false;
+    }
+    if (rtp_is_comfort_noise(payload_type)) {
+        stats->comfort_noise++;
+        regular = false;
+    }
+    if (stream->telephone_event) {
+        stats->telephone_event++;
+        regular = false;
+    }
+    if (!rtp_timestamp_in_sequence(stats, ts)) {
+        stats->wrong_timestamp++;
+        regular = false;
+        accepted = false;
+    }
 
     if (ext_seq > stats->max_seq) {
         if (ext_seq > stats->max_seq + 1)
@@ -210,11 +248,18 @@ stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
         double current_ms = ptime.tv_sec * 1000.0 + ptime.tv_usec / 1000.0;
         double delta = current_ms - last_ms;
 
-        if (delta > stats->max_delta)
+        if (regular && delta > stats->max_delta)
             stats->max_delta = delta;
+        if (regular) {
+            if (!stats->delta_samples || delta < stats->min_delta)
+                stats->min_delta = delta;
+            stats->delta_samples++;
+            stats->mean_delta += (delta - stats->mean_delta) / stats->delta_samples;
+            stats->regular++;
+        }
     }
 
-    if (clock) {
+    if (clock && !stream->telephone_event) {
         double arrival = ptime.tv_sec * (double) clock +
                          ptime.tv_usec * (double) clock / 1000000.0;
         double transit = arrival - ts;
@@ -226,11 +271,15 @@ stream_update_rtp_stats(rtp_stream_t *stream, packet_t *packet)
             stats->jitter += (d - stats->jitter) / 16.0;
         stats->transit = transit;
         stats->jitter_ms = stats->jitter * 1000 / clock;
-        if (stats->jitter_ms > stats->max_jitter)
-            stats->max_jitter = stats->jitter_ms;
-        stats->jitter_samples++;
-        stats->mean_jitter += (stats->jitter_ms - stats->mean_jitter) /
-                              stats->jitter_samples;
+        if (regular) {
+            if (stats->jitter_ms > stats->max_jitter)
+                stats->max_jitter = stats->jitter_ms;
+            if (!stats->jitter_samples || stats->jitter_ms < stats->min_jitter)
+                stats->min_jitter = stats->jitter_ms;
+            stats->jitter_samples++;
+            stats->mean_jitter += (stats->jitter_ms - stats->mean_jitter) /
+                                  stats->jitter_samples;
+        }
     }
 
     stats->last_seq = seq;

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -38,6 +38,8 @@
 
 // Version is the first 2 bits of the first octet
 #define RTP_VERSION(octet) ((octet) >> 6)
+// Marker is the first bit in the second octet
+#define RTP_MARKER(octet) ((octet) >> 7)
 // Payload type is the last 7 bits
 #define RTP_PAYLOAD_TYPE(octet) ((octet) & 0x7F)
 
@@ -139,20 +141,38 @@ struct rtp_stats {
     uint32_t duplicates;
     //! Out-of-order RTP packets
     uint32_t outoforder;
+    //! RTP packets with marker bit set
+    uint32_t marker;
+    //! Comfort noise RTP packets
+    uint32_t comfort_noise;
+    //! Telephone-event RTP packets
+    uint32_t telephone_event;
+    //! RTP packets with a timestamp older than the first packet
+    uint32_t wrong_timestamp;
     //! Jitter calculated using RFC3550, in RTP timestamp units
     double jitter;
     //! Previous packet transit time for jitter calculation
     double transit;
     //! Max capture delta between accepted RTP packets, in ms
     double max_delta;
+    //! Min capture delta between regular RTP packets, in ms
+    double min_delta;
+    //! Mean capture delta between regular RTP packets, in ms
+    double mean_delta;
+    //! Number of delta samples used for mean delta
+    uint32_t delta_samples;
     //! Jitter calculated using RFC3550, in ms
     double jitter_ms;
     //! Max jitter found in the stream, in ms
     double max_jitter;
+    //! Min jitter found in the stream, in ms
+    double min_jitter;
     //! Mean jitter of the stream, in ms
     double mean_jitter;
     //! Number of jitter samples used for mean jitter
     uint32_t jitter_samples;
+    //! Regular RTP packets included in delta/jitter aggregates
+    uint32_t regular;
 };
 
 struct rtp_stream {

--- a/src/rtp.h
+++ b/src/rtp.h
@@ -101,11 +101,58 @@ typedef struct rtp_encoding rtp_encoding_t;
 typedef struct rtp_stream rtp_stream_t;
 //! Shorter declaration of rtp_event structure
 typedef struct rtp_event rtp_event_t;
+//! Shorter declaration of rtp_stats structure
+typedef struct rtp_stats rtp_stats_t;
 
 struct rtp_encoding {
     uint32_t id;
     const char *name;
     const char *format;
+};
+
+struct rtp_stats {
+    //! RTP stats have received at least one RTP packet
+    bool initialized;
+    //! Payload type from the last received RTP packet
+    uint8_t payload_type;
+    //! Synchronization source identifier
+    uint32_t ssrc;
+    //! First received RTP sequence number
+    uint16_t first_seq;
+    //! Last received RTP sequence number
+    uint16_t last_seq;
+    //! Highest received extended RTP sequence number
+    uint32_t max_seq;
+    //! Extended RTP sequence number of the first packet
+    uint32_t base_seq;
+    //! RTP sequence wrap cycles
+    uint32_t cycles;
+    //! First received RTP timestamp
+    uint32_t first_ts;
+    //! Last received RTP timestamp
+    uint32_t last_ts;
+    //! Time of last received RTP packet
+    struct timeval last_time;
+    //! Total RTP packets received, including duplicates
+    uint32_t received;
+    //! Duplicate RTP packets
+    uint32_t duplicates;
+    //! Out-of-order RTP packets
+    uint32_t outoforder;
+    //! Jitter calculated using RFC3550, in RTP timestamp units
+    double jitter;
+    //! Previous packet transit time for jitter calculation
+    double transit;
+    //! Max capture delta between accepted RTP packets, in ms
+    double max_delta;
+    //! Jitter calculated using RFC3550, in ms
+    double jitter_ms;
+    //! Max jitter found in the stream, in ms
+    double max_jitter;
+    //! Mean jitter of the stream, in ms
+    double mean_jitter;
+    //! Number of jitter samples used for mean jitter
+    uint32_t jitter_samples;
 };
 
 struct rtp_stream {
@@ -127,6 +174,8 @@ struct rtp_stream {
     int telephone_event;
     //! Telephone events of this stream (rtp_event_t)
     vector_t *events;
+    //! Statistics observed from RTP packets
+    rtp_stats_t rtpstats;
 
     // Stream information (depending on type)
     union {
@@ -137,6 +186,14 @@ struct rtp_stream {
         struct {
             //! Sender packet count
             uint32_t spc;
+            //! Cumulative packets lost
+            int32_t lost;
+            //! Extended highest sequence number received
+            uint32_t hseq;
+            //! Interarrival jitter
+            uint32_t jitter;
+            //! RTCP report data has been received
+            bool reported;
             //! Fraction lost x/256
             uint8_t flost;
             //! uint8_t discarded x/256
@@ -319,6 +376,18 @@ stream_add_packet(rtp_stream_t *stream, packet_t *packet);
 uint32_t
 stream_get_count(rtp_stream_t *stream);
 
+uint32_t
+stream_get_expected_count(rtp_stream_t *stream);
+
+uint32_t
+stream_get_lost_count(rtp_stream_t *stream);
+
+uint32_t
+stream_get_duration_ms(rtp_stream_t *stream);
+
+uint32_t
+stream_get_clock_rate(rtp_stream_t *stream);
+
 struct sip_call *
 stream_get_call(rtp_stream_t *stream);
 
@@ -342,6 +411,9 @@ rtp_find_call_stream(struct sip_call *call, address_t src, address_t dst);
 
 rtp_stream_t *
 rtp_find_call_exact_stream(struct sip_call *call, address_t src, address_t dst);
+
+rtp_stream_t *
+rtp_find_related_rtcp_stream(rtp_stream_t *rtp);
 
 /**
  * @brief Check if a message is older than other

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2,7 +2,7 @@ AUTOMAKE_OPTIONS=subdir-objects
 
 check_PROGRAMS=test-001 test-002 test-003 test-004 test-005
 check_PROGRAMS+=test-006 test-007 test-008 test-009 test-010
-check_PROGRAMS+=test-011
+check_PROGRAMS+=test-011 test-012
 
 test_001_SOURCES=test_001.c
 test_002_SOURCES=test_002.c
@@ -15,5 +15,6 @@ test_008_SOURCES=test_008.c
 test_009_SOURCES=test_009.c
 test_010_SOURCES=test_010.c ../src/hash.c
 test_011_SOURCES=test_011.c
+test_012_SOURCES=test_012.c ../src/packet.c ../src/vector.c ../src/util.c ../src/address.c
 
 TESTS = $(check_PROGRAMS)

--- a/tests/test_012.c
+++ b/tests/test_012.c
@@ -1,0 +1,168 @@
+/**************************************************************************
+ **
+ ** sngrep - SIP Messages flow viewer
+ **
+ ** Copyright (C) 2013-2018 Ivan Alonso (Kaian)
+ ** Copyright (C) 2013-2018 Irontec SL. All rights reserved.
+ **
+ ** This program is free software: you can redistribute it and/or modify
+ ** it under the terms of the GNU General Public License as published by
+ ** the Free Software Foundation, either version 3 of the License, or
+ ** (at your option) any later version.
+ **
+ ****************************************************************************/
+/**
+ * @file test_012.c
+ *
+ * Basic RTP stream statistics tests.
+ */
+
+#include "config.h"
+#ifdef WITH_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#endif
+#include <assert.h>
+#include <string.h>
+#include "../src/packet.h"
+#include "../src/rtp.h"
+#include "../src/sip.h"
+
+vector_iter_t
+sip_calls_iterator()
+{
+    vector_iter_t it;
+    memset(&it, 0, sizeof(it));
+    return it;
+}
+
+struct sip_call *
+msg_get_call(const sip_msg_t *msg)
+{
+    (void) msg;
+    return NULL;
+}
+
+void
+call_add_stream(sip_call_t *call, rtp_stream_t *stream)
+{
+    (void) call;
+    (void) stream;
+}
+
+const char *
+media_get_format(sdp_media_t *media, uint32_t code)
+{
+    (void) media;
+    (void) code;
+    return NULL;
+}
+
+#include "../src/rtp.c"
+
+static packet_t *
+rtp_packet(uint16_t seq, uint32_t ts, uint32_t usec)
+{
+    address_t src = { "10.0.0.1", 10000 };
+    address_t dst = { "10.0.0.2", 20000 };
+    struct pcap_pkthdr header;
+    packet_t *packet = packet_create(4, IPPROTO_UDP, src, dst, 1);
+    u_char payload[RTP_HDR_LENGTH] = { 0x80, 0x00 };
+
+    memset(&header, 0, sizeof(header));
+    header.ts.tv_sec = usec / 1000000;
+    header.ts.tv_usec = usec % 1000000;
+    header.caplen = sizeof(payload);
+    header.len = sizeof(payload);
+
+    payload[2] = seq >> 8;
+    payload[3] = seq & 0xff;
+    payload[4] = ts >> 24;
+    payload[5] = (ts >> 16) & 0xff;
+    payload[6] = (ts >> 8) & 0xff;
+    payload[7] = ts & 0xff;
+    payload[8] = 0x12;
+    payload[9] = 0x34;
+    payload[10] = 0x56;
+    payload[11] = 0x78;
+
+    packet_add_frame(packet, &header, payload);
+    packet_set_payload(packet, payload, sizeof(payload));
+    return packet;
+}
+
+static void
+add_rtp(rtp_stream_t *stream, uint16_t seq, uint32_t ts, uint32_t usec)
+{
+    packet_t *packet = rtp_packet(seq, ts, usec);
+    stream_add_packet(stream, packet);
+    packet_destroy(packet);
+}
+
+int
+main()
+{
+    address_t dst = { "10.0.0.2", 20000 };
+    rtp_stream_t *stream;
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 0, 0);
+    add_rtp(stream, 11, 160, 20000);
+    add_rtp(stream, 12, 320, 40000);
+    assert(stream_get_expected_count(stream) == 3);
+    assert(stream_get_lost_count(stream) == 0);
+    assert(stream->rtpstats.duplicates == 0);
+    assert(stream->rtpstats.outoforder == 0);
+    assert(stream_get_duration_ms(stream) == 40);
+    assert(stream_get_clock_rate(stream) == 8000);
+    assert(stream->rtpstats.max_delta == 20.0);
+    assert(stream->rtpstats.max_jitter == 0.0);
+    assert(stream->rtpstats.mean_jitter == 0.0);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 0, 0);
+    add_rtp(stream, 12, 320, 40000);
+    assert(stream_get_expected_count(stream) == 3);
+    assert(stream_get_lost_count(stream) == 1);
+    assert(stream->rtpstats.outoforder == 1);
+    add_rtp(stream, 11, 160, 20000);
+    assert(stream_get_lost_count(stream) == 0);
+    assert(stream->rtpstats.outoforder == 2);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 0, 0);
+    add_rtp(stream, 10, 0, 0);
+    assert(stream_get_expected_count(stream) == 1);
+    assert(stream_get_lost_count(stream) == 0);
+    assert(stream->rtpstats.duplicates == 1);
+    assert(stream->rtpstats.outoforder == 1);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 65534, 0, 0);
+    add_rtp(stream, 65535, 160, 20000);
+    add_rtp(stream, 0, 320, 40000);
+    add_rtp(stream, 65535, 160, 20000);
+    assert(stream_get_expected_count(stream) == 3);
+    assert(stream_get_lost_count(stream) == 0);
+    assert(stream->rtpstats.outoforder == 1);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 0, 0);
+    add_rtp(stream, 11, 160, 30000);
+    assert(stream->rtpstats.max_delta == 30.0);
+    assert(stream->rtpstats.max_jitter > 0.62);
+    assert(stream->rtpstats.max_jitter < 0.63);
+    assert(stream->rtpstats.mean_jitter > 0.62);
+    assert(stream->rtpstats.mean_jitter < 0.63);
+    sng_free(stream);
+
+    return 0;
+}

--- a/tests/test_012.c
+++ b/tests/test_012.c
@@ -60,7 +60,8 @@ media_get_format(sdp_media_t *media, uint32_t code)
 #include "../src/rtp.c"
 
 static packet_t *
-rtp_packet(uint16_t seq, uint32_t ts, uint32_t usec)
+rtp_packet_ex(uint16_t seq, uint32_t ts, uint32_t usec, uint8_t payload_type,
+              bool marker)
 {
     address_t src = { "10.0.0.1", 10000 };
     address_t dst = { "10.0.0.2", 20000 };
@@ -74,6 +75,7 @@ rtp_packet(uint16_t seq, uint32_t ts, uint32_t usec)
     header.caplen = sizeof(payload);
     header.len = sizeof(payload);
 
+    payload[1] = payload_type | (marker ? 0x80 : 0);
     payload[2] = seq >> 8;
     payload[3] = seq & 0xff;
     payload[4] = ts >> 24;
@@ -91,11 +93,18 @@ rtp_packet(uint16_t seq, uint32_t ts, uint32_t usec)
 }
 
 static void
-add_rtp(rtp_stream_t *stream, uint16_t seq, uint32_t ts, uint32_t usec)
+add_rtp_ex(rtp_stream_t *stream, uint16_t seq, uint32_t ts, uint32_t usec,
+           uint8_t payload_type, bool marker)
 {
-    packet_t *packet = rtp_packet(seq, ts, usec);
+    packet_t *packet = rtp_packet_ex(seq, ts, usec, payload_type, marker);
     stream_add_packet(stream, packet);
     packet_destroy(packet);
+}
+
+static void
+add_rtp(rtp_stream_t *stream, uint16_t seq, uint32_t ts, uint32_t usec)
+{
+    add_rtp_ex(stream, seq, ts, usec, 0, false);
 }
 
 int
@@ -116,8 +125,13 @@ main()
     assert(stream_get_duration_ms(stream) == 40);
     assert(stream_get_clock_rate(stream) == 8000);
     assert(stream->rtpstats.max_delta == 20.0);
+    assert(stream->rtpstats.min_delta == 20.0);
+    assert(stream->rtpstats.mean_delta == 20.0);
     assert(stream->rtpstats.max_jitter == 0.0);
+    assert(stream->rtpstats.min_jitter == 0.0);
     assert(stream->rtpstats.mean_jitter == 0.0);
+    assert(stream->rtpstats.delta_samples == 2);
+    assert(stream->rtpstats.jitter_samples == 2);
     sng_free(stream);
 
     stream = stream_create(NULL, dst, PACKET_RTP);
@@ -158,10 +172,43 @@ main()
     add_rtp(stream, 10, 0, 0);
     add_rtp(stream, 11, 160, 30000);
     assert(stream->rtpstats.max_delta == 30.0);
+    assert(stream->rtpstats.min_delta == 30.0);
+    assert(stream->rtpstats.mean_delta == 30.0);
     assert(stream->rtpstats.max_jitter > 0.62);
     assert(stream->rtpstats.max_jitter < 0.63);
+    assert(stream->rtpstats.min_jitter > 0.62);
+    assert(stream->rtpstats.min_jitter < 0.63);
     assert(stream->rtpstats.mean_jitter > 0.62);
     assert(stream->rtpstats.mean_jitter < 0.63);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 0, 0);
+    add_rtp_ex(stream, 11, 160, 20000, 0, true);
+    add_rtp(stream, 12, 320, 40000);
+    assert(stream->rtpstats.marker == 1);
+    assert(stream->rtpstats.delta_samples == 1);
+    assert(stream->rtpstats.max_delta == 20.0);
+    assert(stream->rtpstats.mean_delta == 20.0);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 13);
+    add_rtp_ex(stream, 10, 0, 0, 13, false);
+    add_rtp_ex(stream, 11, 160, 20000, 13, false);
+    assert(stream->rtpstats.comfort_noise == 2);
+    assert(stream->rtpstats.delta_samples == 0);
+    assert(stream->rtpstats.jitter_samples == 0);
+    sng_free(stream);
+
+    stream = stream_create(NULL, dst, PACKET_RTP);
+    stream_set_format(stream, 0);
+    add_rtp(stream, 10, 320, 40000);
+    add_rtp(stream, 11, 160, 60000);
+    assert(stream->rtpstats.wrong_timestamp == 1);
+    assert(stream->rtpstats.delta_samples == 0);
+    assert(stream->rtpstats.jitter_samples == 0);
     sng_free(stream);
 
     return 0;


### PR DESCRIPTION
## Summary

When an RTP arrow is selected, sngrep now displays a right-side **RTP Stream Analysis** panel with packet counters, loss estimation, sequence anomalies, jitter/delta metrics, stream duration, SSRC, codec/payload information, and related RTCP data when available.

Related to https://github.com/irontec/sngrep/issues/412

This pull request was drafted with the assistance of AI.

## Main Changes

- Parse minimal RTP header fields:
  - payload type
  - marker bit
  - sequence number
  - RTP timestamp
  - SSRC

- Track RTP stream statistics:
  - received packets
  - expected packets
  - estimated lost packets
  - duplicates
  - out-of-sequence packets
  - sequence range
  - RTP timestamp range
  - stream duration
  - max/mean delta
  - min/max/mean jitter
  - RFC3550 jitter in RTP timestamp units and milliseconds

- Handle 16-bit RTP sequence number wraparound.
- Exclude marker, comfort noise, telephone-event, and wrong-timestamp packets from jitter/delta aggregates, closer to Wireshark’s RTP analysis behavior.

- Parse additional RTCP report data:
  - sender packet count
  - fraction lost
  - cumulative lost
  - highest sequence
  - interarrival jitter
  - existing RTCP XR VoIP metrics when available

- Show RTCP information only when related RTCP data is available.
- Keep Call Flow arrow labels compact and unchanged.

## Tests

Added focused RTP statistics tests covering:

- continuous sequence with no loss
- missing sequence/loss estimation
- late packet handling
- duplicate handling
- `65535 -> 0` sequence wrap
- jitter/delta calculation
- marker packet exclusion
- comfort noise exclusion
- wrong RTP timestamp handling