### PR TITLE
Fix capture dumper close race

### DIFF
--- a/src/capture.c
+++ b/src/capture.c
@@ -1014,16 +1014,8 @@ capture_close()
 {
     capture_info_t *capinfo;
 
-    // Nothing to close
-    if (vector_count(capture_cfg.sources) == 0)
-        return;
-
-    // Close dump file
-    if (capture_cfg.pd) {
-        dump_close(capture_cfg.pd);
-    }
-
-    // Stop all captures
+    // Stop all captures before closing the shared dumper.  Otherwise a live
+    // capture thread can still call pcap_dump() on a closed FILE handle.
     vector_iter_t it = vector_iterator(capture_cfg.sources);
     while ((capinfo = vector_iterator_next(&it))) {
         //Close PCAP file
@@ -1038,8 +1030,17 @@ capture_close()
                 }
                 pthread_cancel(capinfo->capture_t);
                 pthread_join(capinfo->capture_t, NULL);
+                capinfo->running = false;
             }
         }
+    }
+
+    // Close dump file after capture threads have stopped using it.
+    if (capture_cfg.pd) {
+        dump_close(capture_cfg.pd);
+        capture_cfg.pd = NULL;
+        capture_cfg.dumpfilename = NULL;
+        capture_cfg.dump_inode = 0;
     }
 
 }

--- a/src/hash.c
+++ b/src/hash.c
@@ -57,6 +57,21 @@ htable_create(size_t size)
 void
 htable_destroy(htable_t *table)
 {
+    size_t i;
+    hentry_t *entry, *next;
+
+    if (!table)
+        return;
+
+    for (i = 0; i < table->size; i++) {
+        entry = table->buckets[i];
+        while (entry) {
+            next = entry->next;
+            free(entry);
+            entry = next;
+        }
+    }
+
     free(table->buckets);
     free(table);
 }

--- a/src/vector.c
+++ b/src/vector.c
@@ -157,7 +157,7 @@ vector_append(vector_t *vector, void *item)
         // Add more memory to the list
         vector->list = realloc(vector->list, sizeof(void *) * vector->limit);
         // Initialize new allocated memory
-        memset(vector->list + vector->limit - vector->step, 0, vector->step);
+        memset(vector->list + vector->limit - vector->step, 0, sizeof(void *) * vector->step);
     }
 
     // Add item to the end of the list
@@ -404,4 +404,3 @@ vector_iterator_reset(vector_iter_t *it)
 {
     vector_iterator_set_current(it, -1);
 }
-


### PR DESCRIPTION
Fixes a crash observed during live capture where sngrep aborted in pcap_dump()/glibc free while running with capture output enabled. capture_close() closed the shared pcap dumper before stopping capture threads, leaving a window where a capture thread could still write to a closed FILE handle. This change stops and joins capture threads before closing the dumper, then clears the dumper state. It also hardens nearby container cleanup by zeroing the correct byte count when vectors grow and freeing chained hash entries on destroy.

Validated on a live SIP box with patched sngrep -rc, valgrind /usr/local/bin/sngrep -rcN, and valgrind /usr/local/bin/sngrep -rcN -l 50 to force call rotation. Both valgrind runs ended with ERROR SUMMARY: 0 errors.