### PR TITLE
rtp: Only check active calls when matching RTP streams

### DIFF
--- a/src/rtp.c
+++ b/src/rtp.c
@@ -429,7 +429,7 @@ rtp_find_stream_format(address_t src, address_t dst, uint32_t format)
     rtp_stream_t *candidate = NULL;
 
     // Get active calls (during conversation)
-    calls = sip_calls_iterator();
+    calls = sip_active_calls_iterator();
     vector_iterator_set_current(&calls, vector_iterator_count(&calls));
 
     while ((call = vector_iterator_prev(&calls))) {


### PR DESCRIPTION
This significantly reduces processing time when loading large PCAPs (and probably during a live capture as well) as the number of total calls increases.

The times to load a 1.4GB offline capture file with 2049 dialogs against the `master` branch and this change are
(times are minutes:seconds.millis):

|                   | master   | patched  |
|-------------------|----------|----------|
| without `-r` flag | 5:30.873 | 1:00.339 |
|    with `-r` flag | 7:45.564 | 1:04.342 |