### PR TITLE
util: check valid length parameter in sng_strncpy

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -119,7 +119,7 @@ sng_basename(const char *name)
 char *
 sng_strncpy(char *dst, const char *src, size_t len)
 {
-    if (dst == NULL || src == NULL) {
+    if (dst == NULL || src == NULL || len == 0) {
         return NULL;
     }
     strncpy(dst, src, len-1);


### PR DESCRIPTION
This pull request makes a small but important change to the `sng_strncpy` function in `src/util.c`.
The function now checks that the `len` parameter is greater than zero, preventing potential issues when copying zero or negative lengths.

Fixes #541 