### PR TITLE
main.c: Don't manually free memory on exit

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -529,12 +529,6 @@ main(int argc, char* argv[])
     // Deinitialize interface
     ncurses_deinit();
 
-    // Deinitialize configuration options
-    deinit_options();
-
-    // Deallocate sip stored messages
-    sip_deinit();
-
     // Leaving!
     return 0;
 }


### PR DESCRIPTION
Manually freeing all of the call list vectors and hash tables just burns CPU when the OS will do it for us when we exit anyway.