### PR TITLE
util: Fix field truncations in `sng_strncpy(…)` usage

### DIFF
--- a/src/curses/ui_call_list.c
+++ b/src/curses/ui_call_list.c
@@ -818,10 +818,7 @@ call_list_handle_form_key(ui_t *ui, int key)
     form_driver(info->form, REQ_VALIDATION);
 
     // Store dfilter input
-    int field_len = strlen(field_buffer(info->fields[FLD_LIST_FILTER], 0));
-    dfilter = malloc(field_len + 1);
-    memset(dfilter, 0, field_len + 1);
-    sng_strncpy(dfilter, field_buffer(info->fields[FLD_LIST_FILTER], 0), field_len);
+    dfilter = strdup(field_buffer(info->fields[FLD_LIST_FILTER], 0));
     // Trim any trailing spaces
     strtrim(dfilter);
 

--- a/src/media.c
+++ b/src/media.c
@@ -62,7 +62,7 @@ media_destroyer(void *item)
 void
 media_set_type(sdp_media_t *media, const char *type)
 {
-    sng_strncpy(media->type, type, MEDIATYPELEN);
+    sng_strncpy(media->type, type, sizeof(media->type));
 }
 
 void

--- a/src/sip.c
+++ b/src/sip.c
@@ -240,11 +240,11 @@ sip_get_callid(const char* payload, char *callid)
 
     // Try to get Call-ID from payload
     if (regexec(&calls.reg_callid, payload, 3, pmatch, 0) == 0) {
-        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so;
+        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
 
-        // Ensure the copy length does not exceed MAX_CALLID_SIZE - 1
-        if (input_len > MAX_CALLID_SIZE - 1) {
-            input_len = MAX_CALLID_SIZE - 1;
+        // Ensure the copy length does not exceed MAX_CALLID_SIZE
+        if (input_len > MAX_CALLID_SIZE) {
+            input_len = MAX_CALLID_SIZE;
         }
 
         // Copy the matching part of payload
@@ -261,7 +261,7 @@ sip_get_xcallid(const char *payload, char *xcallid)
 
     // Try to get X-Call-ID from payload
     if (regexec(&calls.reg_xcallid, (const char *)payload, 3, pmatch, 0) == 0) {
-        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so;
+        int input_len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
 
         // Ensure the copy length does not exceed MAX_XCALLID_SIZE
         if (input_len > MAX_XCALLID_SIZE) {
@@ -308,7 +308,7 @@ sip_validate_packet(packet_t *packet)
     }
 
     // Ensure the copy length does not exceed MAX_CONTENT_LENGTH_SIZE
-    int cl_match_len = pmatch[2].rm_eo - pmatch[2].rm_so;
+    int cl_match_len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
     if (cl_match_len > MAX_CONTENT_LENGTH_SIZE) {
         cl_match_len = MAX_CONTENT_LENGTH_SIZE;
     }
@@ -641,29 +641,29 @@ sip_parse_msg_payload(sip_msg_t *msg, const u_char *payload)
 
     // From
     if (regexec(&calls.reg_from, (const char *)payload, 4, pmatch, 0) == 0) {
-        msg->sip_from = sng_malloc((int)pmatch[2].rm_eo - pmatch[2].rm_so + 1);
-        sng_strncpy(msg->sip_from, (const char *)payload +  pmatch[2].rm_so, (int)pmatch[2].rm_eo - pmatch[2].rm_so);
+        int len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
+        msg->sip_from = sng_malloc(len);
+        sng_strncpy(msg->sip_from, (const char *)payload +  pmatch[2].rm_so, len);
     } else {
         // Malformed From Header
-        msg->sip_from = sng_malloc(12);
-        sng_strncpy(msg->sip_from, "<malformed>", 12);
+        msg->sip_from = strdup("<malformed>");
     }
 
     // To
     if (regexec(&calls.reg_to, (const char *)payload, 4, pmatch, 0) == 0) {
-        msg->sip_to = sng_malloc((int)pmatch[2].rm_eo - pmatch[2].rm_so + 1);
-        sng_strncpy(msg->sip_to, (const char *)payload +  pmatch[2].rm_so, (int)pmatch[2].rm_eo - pmatch[2].rm_so);
+        int len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
+        msg->sip_to = sng_malloc(len);
+        sng_strncpy(msg->sip_to, (const char *)payload +  pmatch[2].rm_so, len);
     } else {
         // Malformed To Header
-        msg->sip_to = sng_malloc(12);
-        sng_strncpy(msg->sip_to, "<malformed>", 12);
+        msg->sip_to = strdup("<malformed>");
     }
 
     // Contact
     if (regexec(&calls.reg_contact, (const char *)payload, 3, pmatch, 0) == 0) {
-        int len = (int)pmatch[2].rm_eo - pmatch[2].rm_so;
-        msg->sip_contact = sng_malloc(len + 1);
-        sng_strncpy(msg->sip_contact, (const char *)payload + pmatch[2].rm_so, len + 1);
+        int len = pmatch[2].rm_eo - pmatch[2].rm_so + 1;
+        msg->sip_contact = sng_malloc(len);
+        sng_strncpy(msg->sip_contact, (const char *)payload + pmatch[2].rm_so, len);
     }
 
     return 0;
@@ -746,11 +746,11 @@ sip_parse_msg_media(sip_msg_t *msg, const u_char *payload)
         // Check if we have a connection string
         if (!strncmp(line, "c=", 2)) {
             if (sscanf(line, "c=IN IP%*c %" STRINGIFY(ADDRESSLEN) "s", address)) {
-                sng_strncpy(dst.ip, address, ADDRESSLEN);
+                sng_strncpy(dst.ip, address, sizeof(dst.ip));
                 if (media) {
                     media_set_address(media, dst);
-                    sng_strncpy(rtp_stream->dst.ip, dst.ip, ADDRESSLEN);
-                    sng_strncpy(rtcp_stream->dst.ip, dst.ip, ADDRESSLEN);
+                    sng_strncpy(rtp_stream->dst.ip, dst.ip, sizeof(rtp_stream->dst.ip));
+                    sng_strncpy(rtcp_stream->dst.ip, dst.ip, sizeof(rtcp_stream->dst.ip));
                 }
             }
         }
@@ -788,16 +788,17 @@ sip_parse_extra_headers(sip_msg_t *msg, const u_char *payload)
 
      // Reason text
      if (regexec(&calls.reg_reason, (const char *)payload, 2, pmatch, 0) == 0) {
-         msg->call->reasontxt = sng_malloc((int)pmatch[1].rm_eo - pmatch[1].rm_so + 1);
-         sng_strncpy(msg->call->reasontxt, (const char *)payload +  pmatch[1].rm_so, (int)pmatch[1].rm_eo - pmatch[1].rm_so);
+         int len = pmatch[1].rm_eo - pmatch[1].rm_so + 1;
+         msg->call->reasontxt = sng_malloc(len);
+         sng_strncpy(msg->call->reasontxt, (const char *)payload +  pmatch[1].rm_so, len);
      }
 
      // Warning code
      if (regexec(&calls.reg_warning, (const char *)payload, 2, pmatch, 0) == 0) {
 
         // Ensure the copy length does not exceed MAX_WARNING_SIZE
-        int warning_match_len = pmatch[1].rm_eo - pmatch[1].rm_so;
-        if (warning_match_len > 0) {
+        int warning_match_len = pmatch[1].rm_eo - pmatch[1].rm_so + 1;
+        if (warning_match_len > 1) {
             if (warning_match_len > MAX_WARNING_SIZE) {
                 warning_match_len = MAX_WARNING_SIZE;
             }

--- a/src/sip_msg.c
+++ b/src/sip_msg.c
@@ -147,12 +147,12 @@ msg_get_attribute(sip_msg_t *msg, int id, char *value)
             break;
         case SIP_ATTR_SIPFROMUSER:
             if (msg->sip_from && (ar = strchr(msg->sip_from, '@'))) {
-                sng_strncpy(value, msg->sip_from, ar - msg->sip_from);
+                sng_strncpy(value, msg->sip_from, ar - msg->sip_from + 1);
             }
             break;
         case SIP_ATTR_SIPTOUSER:
             if (msg->sip_to && (ar = strchr(msg->sip_to, '@'))) {
-                sng_strncpy(value, msg->sip_to, ar - msg->sip_to);
+                sng_strncpy(value, msg->sip_to, ar - msg->sip_to + 1);
             }
             break;
         case SIP_ATTR_DATE:

--- a/src/util.h
+++ b/src/util.h
@@ -57,8 +57,12 @@ sng_free(void *ptr);
 char *
 sng_basename(const char *name);
 
-/*
+/**
  * @brief Wrapper for strncpy
+ *
+ * @param dst The destination buffer
+ * @param src The source string
+ * @param len The number of bytes available to be written in `dst`
  */
 char *
 sng_strncpy(char *dst, const char *src, size_t len);


### PR DESCRIPTION
Commit df59a5a introduced the `sng_strncpy(…)` wrapper but some invocations were not passing the correct value for the `len` argument. The `len` argument is the total amount of space available in `dst` in which to write the `src` string and its 0 terminator, not simply the number of characters in the source string.

Some invocations were passing the number of characters available in `src` resulting in the truncation of the last character.